### PR TITLE
Fix: forward HAPI FHIR error responses instead of raw got HTTPError objects

### DIFF
--- a/src/routes/fhir.ts
+++ b/src/routes/fhir.ts
@@ -82,8 +82,14 @@ router.get('/:resource/:id?/:operation?', async (req: Request, res: Response) =>
     }
 
     res.status(200).json(result)
-  } catch (error) {
-    return res.status(500).json(error)
+  } catch (error: any) {
+    const statusCode = error?.response?.statusCode || 500
+    const body = error?.response?.body
+    try {
+      return res.status(statusCode).json(body ? JSON.parse(body) : { error: error.message })
+    } catch {
+      return res.status(statusCode).json({ error: error.message })
+    }
   }
 })
 
@@ -107,8 +113,14 @@ router.post('/', async (req, res) => {
     const ret = await got.post(uri.toString(), { json: resource })
 
     res.status(ret.statusCode).json(JSON.parse(ret.body))
-  } catch (error) {
-    return res.status(500).json(error)
+  } catch (error: any) {
+    const statusCode = error?.response?.statusCode || 500
+    const body = error?.response?.body
+    try {
+      return res.status(statusCode).json(body ? JSON.parse(body) : { error: error.message })
+    } catch {
+      return res.status(statusCode).json({ error: error.message })
+    }
   }
 })
 
@@ -166,8 +178,17 @@ export async function saveResource(req: any, res: any, operation?: string) {
     });
 
     res.status(ret.statusCode).json(JSON.parse(ret.body))
-  } catch (error) {
-    res.status(500).json(errorFromHapi || error)
+  } catch (error: any) {
+    const statusCode = error?.response?.statusCode || 500
+    if (errorFromHapi) {
+      return res.status(statusCode).json(errorFromHapi)
+    }
+    const body = error?.response?.body
+    try {
+      return res.status(statusCode).json(body ? JSON.parse(body) : { error: error.message })
+    } catch {
+      return res.status(statusCode).json({ error: error.message })
+    }
   }
 }
     


### PR DESCRIPTION
## Summary

When HAPI FHIR returns a non-2xx response (e.g. 400 for referential integrity violations), the `got` library throws an `HTTPError`. All three catch blocks in `src/routes/fhir.ts` were passing this raw error object to `res.json(error)`, which serialized internal `got` state (circular references, timings, socket info) instead of the actual FHIR `OperationOutcome` from HAPI.

### What this caused

- OpenHIM forwarded a 500 with a non-FHIR response body containing `got` internals
- FHIR clients (e.g. fhir-data-pipes) failed with `InternalErrorException: HTTP 500 Internal Server Error`
- The actual HAPI error message (e.g. referential integrity violation details) was lost

### Fix

Extract `error.response.statusCode` and `error.response.body` from the `HTTPError` to forward HAPI's actual response with its original status code. Falls back to `{ error: error.message }` if no response body is available.

Applied to all three catch blocks:
- `GET /:resource/:id?/:operation?` (line 85)
- `POST /` bundle handler (line 110)
- `saveResource` for `PUT/POST /:resourceType` (line 181)

### Before
```
HTTP 500 → {"name":"HTTPError","code":"ERR_NON_2XX_3XX_RESPONSE","timings":{...socket internals...}}
```

### After
```
HTTP 400 → {"resourceType":"OperationOutcome","issue":[{"severity":"error","code":"processing","diagnostics":"HAPI-1094: Resource Encounter/xxx not found"}]}
```

## Test plan
- [ ] POST a bundle with an invalid reference to `/fhir/` — should return HAPI's `OperationOutcome` with the original status code (e.g. 400), not a 500 with `got` internals
- [ ] GET a non-existent resource — should return HAPI's 404 response, not a 500
- [ ] PUT a resource that triggers a HAPI validation error — should forward the error correctly