### PR TITLE
CI: enable Docker build for fork PRs with environment gate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CI/CD
 
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
   push:
     branches: [main]
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - uses: actions/setup-node@v3
         with:
@@ -43,14 +45,15 @@ jobs:
         run: yarn test:unit
 
   build-and-deploy:
-    # Skip Docker build/push for PRs from forks (repo secrets not available)
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    environment: ${{ github.event_name == 'pull_request_target' && 'docker-build' || '' }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Dump github context
         run:   echo "$GITHUB_CONTEXT"
         shell: bash
@@ -81,8 +84,8 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          load: ${{ github.event_name == 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request_target' }}
+          load: ${{ github.event_name == 'pull_request_target' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{github.repository}}:latest


### PR DESCRIPTION
## Summary
- Replace `pull_request` with `pull_request_target` so fork PRs have access to repo secrets for Docker login/build
- Gate the `build-and-deploy` job behind a `docker-build` environment with required reviewers, so maintainers must approve before untrusted fork code runs with secrets
- Explicitly checkout the PR head SHA (since `pull_request_target` defaults to the base branch)

## Setup required
After merging, create a **`docker-build`** environment in repo Settings → Environments with at least one required reviewer.

## Test plan
- [ ] Create the `docker-build` environment with a required reviewer
- [ ] Open a PR from a fork and verify the build-and-deploy job waits for approval
- [ ] Approve the environment and verify Docker build succeeds with secrets
- [ ] Verify push to main still builds and pushes without approval gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)