### PR TITLE
Accept empty bundles gracefully instead of returning 400

### DIFF
--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -5,12 +5,24 @@ import got from 'got'
 import logger from '../lib/winston'
 
 export function invalidBundle(resource: any): boolean {
-  return (
-    !resource.resourceType ||
-    (resource.resourceType && resource.resourceType !== 'Bundle') ||
-    !resource.entry ||
-    (resource.entry && resource.entry.length === 0)
-  )
+  if (!resource || typeof resource !== 'object' || Array.isArray(resource)) {
+    return true
+  }
+  if (resource.resourceType !== 'Bundle') {
+    return true
+  }
+  if ('entry' in resource && !Array.isArray(resource.entry)) {
+    return true
+  }
+  return false
+}
+
+export function emptyBundle(resource: any): boolean {
+  return !Array.isArray(resource.entry) || resource.entry.length === 0
+}
+
+export function emptyBundleResponse(): any {
+  return { resourceType: 'Bundle', type: 'transaction-response', entry: [] }
 }
 
 export function invalidBundleMessage(): any {

--- a/src/routes/__tests__/fhir.test.ts
+++ b/src/routes/__tests__/fhir.test.ts
@@ -3,8 +3,10 @@ import express from 'express'
 import { router } from '../fhir'
 import got from 'got'
 import { saveResource } from '../fhir'
+import { invalidBundle, emptyBundle, emptyBundleResponse } from '../../lib/helpers'
 
 const app = express()
+app.use(express.json())
 app.use('/', router)
 
 describe('FHIR Routes', () => {
@@ -41,4 +43,108 @@ it('should return 500 Internal Server Error when the post request fails', async 
   await saveResource(req, res)
 
   expect(res.status).toHaveBeenCalledWith(400)
+})
+
+describe('invalidBundle', () => {
+  it('rejects null', () => {
+    expect(invalidBundle(null)).toBe(true)
+  })
+
+  it('rejects undefined', () => {
+    expect(invalidBundle(undefined)).toBe(true)
+  })
+
+  it('rejects non-object (string)', () => {
+    expect(invalidBundle('not a bundle')).toBe(true)
+  })
+
+  it('rejects non-object (number)', () => {
+    expect(invalidBundle(42)).toBe(true)
+  })
+
+  it('rejects array', () => {
+    expect(invalidBundle([{ resourceType: 'Bundle' }])).toBe(true)
+  })
+
+  it('rejects missing resourceType', () => {
+    expect(invalidBundle({})).toBe(true)
+  })
+
+  it('rejects non-Bundle resourceType', () => {
+    expect(invalidBundle({ resourceType: 'Patient' })).toBe(true)
+  })
+
+  it('rejects non-array entry (object)', () => {
+    expect(invalidBundle({ resourceType: 'Bundle', entry: {} })).toBe(true)
+  })
+
+  it('rejects non-array entry (string)', () => {
+    expect(invalidBundle({ resourceType: 'Bundle', entry: 'not an array' })).toBe(true)
+  })
+
+  it('accepts Bundle with entries', () => {
+    expect(invalidBundle({ resourceType: 'Bundle', entry: [{ resource: {} }] })).toBe(false)
+  })
+
+  it('accepts Bundle without entry property (empty bundle is valid)', () => {
+    expect(invalidBundle({ resourceType: 'Bundle', type: 'transaction' })).toBe(false)
+  })
+
+  it('accepts Bundle with empty entry array', () => {
+    expect(invalidBundle({ resourceType: 'Bundle', entry: [] })).toBe(false)
+  })
+})
+
+describe('emptyBundle', () => {
+  it('returns true when entry is undefined', () => {
+    expect(emptyBundle({ resourceType: 'Bundle', type: 'transaction' })).toBe(true)
+  })
+
+  it('returns true when entry is empty array', () => {
+    expect(emptyBundle({ resourceType: 'Bundle', entry: [] })).toBe(true)
+  })
+
+  it('returns false when entry has items', () => {
+    expect(emptyBundle({ resourceType: 'Bundle', entry: [{ resource: {} }] })).toBe(false)
+  })
+})
+
+describe('emptyBundleResponse', () => {
+  it('returns a transaction-response Bundle', () => {
+    const resp = emptyBundleResponse()
+    expect(resp.resourceType).toBe('Bundle')
+    expect(resp.type).toBe('transaction-response')
+    expect(resp.entry).toEqual([])
+  })
+})
+
+describe('POST / bundle endpoint', () => {
+  it('returns 400 for non-Bundle resource', async () => {
+    const response = await request(app)
+      .post('/')
+      .send({ resourceType: 'Patient', id: '123' })
+
+    expect(response.status).toBe(400)
+    expect(response.body.issue[0].diagnostics).toBe('Invalid bundle submitted')
+  })
+
+  it('returns 200 with empty response for empty bundle', async () => {
+    const response = await request(app)
+      .post('/')
+      .send({ resourceType: 'Bundle', type: 'transaction' })
+
+    expect(response.status).toBe(200)
+    expect(response.body.resourceType).toBe('Bundle')
+    expect(response.body.type).toBe('transaction-response')
+    expect(response.body.entry).toEqual([])
+  })
+
+  it('returns 200 with empty response for bundle with empty entry array', async () => {
+    const response = await request(app)
+      .post('/')
+      .send({ resourceType: 'Bundle', type: 'transaction', entry: [] })
+
+    expect(response.status).toBe(200)
+    expect(response.body.type).toBe('transaction-response')
+  })
 })

--- a/src/routes/fhir.ts
+++ b/src/routes/fhir.ts
@@ -3,7 +3,7 @@ import express, { Request, Response } from 'express'
 import got from 'got'
 import URI from 'urijs'
 import config from '../lib/config'
-import { getHapiPassthrough, invalidBundle, invalidBundleMessage } from '../lib/helpers'
+import { getHapiPassthrough, invalidBundle, invalidBundleMessage, emptyBundle, emptyBundleResponse } from '../lib/helpers'
 import logger from '../lib/winston'
 import { generateSimpleIpsBundle } from '../workflows/ipsWorkflows'
 import { getResourceTypeEnum, isValidResourceType } from '../lib/validate'
@@ -104,8 +104,9 @@ router.post('/', async (req, res) => {
       return res.status(400).json(invalidBundleMessage())
     }
 
-    if (resource.entry.length === 0) {
-      return res.status(400).json(invalidBundleMessage())
+    if (emptyBundle(resource)) {
+      logger.info('Received empty bundle, returning empty response')
+      return res.status(200).json(emptyBundleResponse())
     }
 
     const uri = URI(config.get('fhirServer:baseURL'))

--- a/src/routes/lab-bw.ts
+++ b/src/routes/lab-bw.ts
@@ -3,7 +3,7 @@
 import { R4 } from '@ahryman40k/ts-fhir-types'
 import express, { Request, Response } from 'express'
 import { saveBundle } from '../hapi/lab'
-import { getMetadata, invalidBundle, invalidBundleMessage } from '../lib/helpers'
+import { getMetadata, invalidBundle, invalidBundleMessage, emptyBundle, emptyBundleResponse } from '../lib/helpers'
 import logger from '../lib/winston'
 import { WorkflowHandler } from '../workflows/botswana/workflowHandler'
 
@@ -31,6 +31,10 @@ router.all('/', async (req: Request, res: Response) => {
       // Validate Bundle
       if (invalidBundle(orderBundle)) {
         return res.status(400).json(invalidBundleMessage())
+      }
+
+      if (emptyBundle(orderBundle)) {
+        return res.status(200).json(emptyBundleResponse())
       }
 
       // Save Bundle

--- a/src/routes/lab.ts
+++ b/src/routes/lab.ts
@@ -3,7 +3,7 @@ import { R4 } from '@ahryman40k/ts-fhir-types'
 import express, { Request, Response } from 'express'
 import got from 'got/dist/source'
 import { saveBundle } from '../hapi/lab'
-import { getMetadata, invalidBundle, invalidBundleMessage } from '../lib/helpers'
+import { getMetadata, invalidBundle, invalidBundleMessage, emptyBundle, emptyBundleResponse } from '../lib/helpers'
 import logger from '../lib/winston'
 import { LabWorkflows } from '../workflows/labWorkflows'
 
@@ -29,6 +29,10 @@ router.all('/', async (req: Request, res: Response) => {
     // Validate Bundle
     if (invalidBundle(orderBundle)) {
       return res.status(400).json(invalidBundleMessage())
+    }
+
+    if (emptyBundle(orderBundle)) {
+      return res.status(200).json(emptyBundleResponse())
     }
 
     let resultBundle: R4.IBundle


### PR DESCRIPTION
## Problem
The FHIR data pipeline (google/fhir-data-pipes) sends empty transaction bundles for resource types with no data:

```json
{"resourceType": "Bundle", "type": "transaction"}
```

The SHR mediator's `invalidBundle()` check rejects these because `entry` is undefined, returning:

```json
{"resourceType": "OperationOutcome", "issue": [{"diagnostics": "Invalid bundle submitted"}]}
```

This 400 response causes the entire Flink pipeline run to fail with:
```
ca.uhn.fhir.rest.server.exceptions.InvalidRequestException: HTTP 400 Bad Request: Invalid bundle submitted
```

## Fix
- Still reject non-Bundle resources with 400
- Return 200 with an empty `transaction-response` Bundle for bundles with no entries, instead of 400

An empty bundle is not an error — it just means there is no data for that resource type.

## Test plan
- [x] Triggered full pipeline run — empty bundles now return 200
- [x] Pipeline completes without