### PR TITLE
Use dedicated CR credentials for MPI lookups

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,8 +43,6 @@ jobs:
         run: yarn test:unit
 
   build-test-push:
-    # Skip Docker build/push on PRs from forks (secrets not available)
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 10
     runs-on: ubuntu-latest
 
@@ -81,8 +79,8 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          load: ${{ github.event_name == 'pull_request' }}
+          push: true
+          load: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{github.repository}}:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,8 @@ jobs:
         run: yarn test:unit
 
   build-test-push:
+    # Skip Docker build/push on PRs from forks (secrets not available)
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 10
     runs-on: ubuntu-latest
 
@@ -79,8 +81,8 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
-          load: false
+          push: ${{ github.event_name != 'pull_request' }}
+          load: ${{ github.event_name == 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{github.repository}}:latest

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -5,12 +5,24 @@ import got from 'got'
 import logger from '../lib/winston'
 
 export function invalidBundle(resource: any): boolean {
-  return (
-    !resource.resourceType ||
-    (resource.resourceType && resource.resourceType !== 'Bundle') ||
-    !resource.entry ||
-    (resource.entry && resource.entry.length === 0)
-  )
+  if (!resource || typeof resource !== 'object' || Array.isArray(resource)) {
+    return true
+  }
+  if (resource.resourceType !== 'Bundle') {
+    return true
+  }
+  if ('entry' in resource && !Array.isArray(resource.entry)) {
+    return true
+  }
+  return false
+}
+
+export function emptyBundle(resource: any): boolean {
+  return !Array.isArray(resource.entry) || resource.entry.length === 0
+}
+
+export function emptyBundleResponse(): any {
+  return { resourceType: 'Bundle', type: 'transaction-response', entry: [] }
 }
 
 export function invalidBundleMessage(): any {

--- a/src/routes/__tests__/fhir.test.ts
+++ b/src/routes/__tests__/fhir.test.ts
@@ -53,7 +53,7 @@ it('should return 500 Internal Server Error when the post request fails', async 
 
   await saveResource(req, res)
 
-  expect(res.status).toHaveBeenCalledWith(400)
+  expect(res.status).toHaveBeenCalledWith(500)
 })
 
 describe('MPI Resolution on Write Path', () => {

--- a/src/routes/__tests__/fhir.test.ts
+++ b/src/routes/__tests__/fhir.test.ts
@@ -1,12 +1,23 @@
 import request from 'supertest'
 import express from 'express'
 import { router } from '../fhir'
-import got from 'got'
 import { saveResource } from '../fhir'
 
 const app = express()
 app.use(express.json())
 app.use('/', router)
+
+// Mock got at module level so all methods are available for spying
+const mockGotGet = jest.fn()
+const mockGotPost = jest.fn()
+const mockGotDefault = jest.fn()
+
+jest.mock('got', () => {
+  const fn = (...args: any[]) => mockGotDefault(...args)
+  fn.get = (...args: any[]) => mockGotGet(...args)
+  fn.post = (...args: any[]) => mockGotPost(...args)
+  return { __esModule: true, default: fn }
+})
 
 // Mock config
 jest.mock('../../lib/config', () => ({
@@ -22,6 +33,34 @@ jest.mock('../../lib/config', () => ({
   },
 }))
 
+const GOLDEN_RECORD_ID = 'b8115fb4-ea19-4578-bc50-05d4a17ca0c7'
+const GOLDEN_RECORD_CODE = '5c827da5-4858-4f3d-a50c-62ece001efea'
+
+const crResponseWithGoldenRecord = {
+  resourceType: 'Bundle',
+  entry: [
+    {
+      resource: {
+        resourceType: 'Patient',
+        id: 'abc-123',
+        meta: { tag: [{ code: 'some-other-code' }] },
+      },
+    },
+    {
+      resource: {
+        resourceType: 'Patient',
+        id: GOLDEN_RECORD_ID,
+        meta: { tag: [{ code: GOLDEN_RECORD_CODE }] },
+      },
+    },
+  ],
+}
+
+const crResponseNoMatch = {
+  resourceType: 'Bundle',
+  entry: [],
+}
+
 describe('FHIR Routes', () => {
   it.skip('should return 200 OK for GET /metadata', async () => {
     const response = await request(app).get('/metadata')
@@ -36,6 +75,8 @@ describe('FHIR Routes', () => {
 })
 
 it('should return 500 Internal Server Error when the post request fails', async () => {
+  mockGotDefault.mockRejectedValueOnce(new Error('request failed'))
+
   const req = {
     body: {},
     params: {
@@ -49,19 +90,120 @@ it('should return 500 Internal Server Error when the post request fails', async 
     json: jest.fn(),
   }
 
-  jest.spyOn(got, 'post').mockRejectedValue(new Error('Post request failed'))
-
   await saveResource(req, res)
 
   expect(res.status).toHaveBeenCalledWith(500)
 })
 
-describe('MPI Resolution on Write Path', () => {
+describe('MPI Resolution via saveResource (POST /Patient, PUT /Patient/:id)', () => {
   afterEach(() => {
-    jest.restoreAllMocks()
+    mockGotGet.mockReset()
+    mockGotPost.mockReset()
+    mockGotDefault.mockReset()
   })
 
-  const goldenRecordId = 'b8115fb4-ea19-4578-bc50-05d4a17ca0c7'
+  const patientBody = {
+    resourceType: 'Patient',
+    id: 'pt-001',
+    name: [{ family: 'Baptiste', given: ['Jean'] }],
+    identifier: [
+      { system: 'http://isanteplus.org/openmrs/fhir2/5-code-national', value: '99999' },
+    ],
+  }
+
+  it('POST /Patient resolves MPI and adds golden record link', async () => {
+    mockGotGet.mockReturnValue({
+      json: () => Promise.resolve(crResponseWithGoldenRecord),
+    })
+
+    mockGotDefault.mockResolvedValue({
+      statusCode: 201,
+      body: JSON.stringify({ resourceType: 'Patient', id: 'pt-001' }),
+    })
+
+    const response = await request(app).post('/Patient').send(patientBody)
+
+    expect(response.status).toBe(201)
+
+    // Verify the CR was queried
+    expect(mockGotGet).toHaveBeenCalled()
+    const crCallUrl = String(mockGotGet.mock.calls[0][0])
+    expect(crCallUrl).toContain('Patient?identifier=')
+
+    // Verify the resource sent to HAPI includes the golden record link
+    const hapiCall = mockGotDefault.mock.calls[0][0]
+    expect(hapiCall.json.link).toContainEqual({
+      other: { reference: `Patient/${GOLDEN_RECORD_ID}` },
+      type: 'refer',
+    })
+  })
+
+  it('PUT /Patient/:id resolves MPI and adds golden record link', async () => {
+    mockGotGet.mockReturnValue({
+      json: () => Promise.resolve(crResponseWithGoldenRecord),
+    })
+
+    mockGotDefault.mockResolvedValue({
+      statusCode: 200,
+      body: JSON.stringify({ resourceType: 'Patient', id: 'pt-001' }),
+    })
+
+    const response = await request(app).put('/Patient/pt-001').send(patientBody)
+
+    expect(response.status).toBe(200)
+
+    // Verify the resource sent to HAPI includes the golden record link
+    const hapiCall = mockGotDefault.mock.calls[0][0]
+    expect(hapiCall.json.link).toContainEqual({
+      other: { reference: `Patient/${GOLDEN_RECORD_ID}` },
+      type: 'refer',
+    })
+    expect(hapiCall.method).toBe('PUT')
+    expect(hapiCall.url).toContain('Patient/pt-001')
+  })
+
+  it('POST /Patient succeeds when CR is unavailable (non-blocking)', async () => {
+    mockGotGet.mockReturnValue({
+      json: () => Promise.reject(new Error('ECONNREFUSED')),
+    })
+
+    mockGotDefault.mockResolvedValue({
+      statusCode: 201,
+      body: JSON.stringify({ resourceType: 'Patient', id: 'pt-001' }),
+    })
+
+    const response = await request(app).post('/Patient').send(patientBody)
+
+    // Write should still succeed
+    expect(response.status).toBe(201)
+
+    // Patient saved without a link
+    const hapiCall = mockGotDefault.mock.calls[0][0]
+    expect(hapiCall.json.link).toBeUndefined()
+  })
+
+  it('POST /Observation skips MPI resolution', async () => {
+    mockGotDefault.mockResolvedValue({
+      statusCode: 201,
+      body: JSON.stringify({ resourceType: 'Observation', id: 'obs-1' }),
+    })
+
+    const response = await request(app)
+      .post('/Observation')
+      .send({ resourceType: 'Observation', id: 'obs-1', status: 'final' })
+
+    expect(response.status).toBe(201)
+    // CR should NOT be queried for non-Patient resources
+    expect(mockGotGet).not.toHaveBeenCalled()
+  })
+})
+
+describe('MPI Resolution on Bundle Write Path', () => {
+  afterEach(() => {
+    mockGotGet.mockReset()
+    mockGotPost.mockReset()
+    mockGotDefault.mockReset()
+  })
 
   const makePatientBundle = (patient: any) => ({
     resourceType: 'Bundle',
@@ -84,42 +226,15 @@ describe('MPI Resolution on Write Path', () => {
     ],
   }
 
-  const crResponseWithGoldenRecord = {
-    resourceType: 'Bundle',
-    entry: [
-      {
-        resource: {
-          resourceType: 'Patient',
-          id: 'abc-123',
-          meta: { tag: [{ code: 'some-other-code' }] },
-        },
-      },
-      {
-        resource: {
-          resourceType: 'Patient',
-          id: goldenRecordId,
-          meta: { tag: [{ code: '5c827da5-4858-4f3d-a50c-62ece001efea' }] },
-        },
-      },
-    ],
-  }
-
-  const crResponseNoMatch = {
-    resourceType: 'Bundle',
-    entry: [],
-  }
-
   it('adds Patient.link to golden record when CR finds a match', async () => {
-    // Mock CR lookup returns golden record
-    const getSpy = jest.spyOn(got, 'get').mockReturnValue({
+    mockGotGet.mockReturnValue({
       json: () => Promise.resolve(crResponseWithGoldenRecord),
-    } as any)
+    })
 
-    // Mock HAPI FHIR write succeeds
-    jest.spyOn(got, 'post').mockResolvedValue({
+    mockGotPost.mockResolvedValue({
       statusCode: 200,
       body: JSON.stringify({ resourceType: 'Bundle', type: 'transaction-response' }),
-    } as any)
+    })
 
     const bundle = makePatientBundle(patientWithIdentifiers)
     const response = await request(app).post('/').send(bundle)
@@ -127,32 +242,29 @@ describe('MPI Resolution on Write Path', () => {
     expect(response.status).toBe(200)
 
     // Verify the CR was queried
-    expect(getSpy).toHaveBeenCalled()
-    const crCallUrl = String(getSpy.mock.calls[0][0])
+    expect(mockGotGet).toHaveBeenCalled()
+    const crCallUrl = String(mockGotGet.mock.calls[0][0])
     expect(crCallUrl).toContain('CR/fhir/Patient?identifier=')
 
     // Verify the patient sent to HAPI FHIR has the golden record link
-    const postSpy = got.post as jest.Mock
-    const sentBundle = postSpy.mock.calls[0][1].json
+    const sentBundle = mockGotPost.mock.calls[0][1].json
     const patient = sentBundle.entry[0].resource
     expect(patient.link).toBeDefined()
     expect(patient.link).toContainEqual({
-      other: { reference: `Patient/${goldenRecordId}` },
+      other: { reference: `Patient/${GOLDEN_RECORD_ID}` },
       type: 'refer',
     })
   })
 
   it('writes patient without link when CR finds no match', async () => {
-    // Mock CR lookup returns no match
-    jest.spyOn(got, 'get').mockReturnValue({
+    mockGotGet.mockReturnValue({
       json: () => Promise.resolve(crResponseNoMatch),
-    } as any)
+    })
 
-    // Mock HAPI FHIR write succeeds
-    jest.spyOn(got, 'post').mockResolvedValue({
+    mockGotPost.mockResolvedValue({
       statusCode: 200,
       body: JSON.stringify({ resourceType: 'Bundle', type: 'transaction-response' }),
-    } as any)
+    })
 
     const bundle = makePatientBundle(patientWithIdentifiers)
     const response = await request(app).post('/').send(bundle)
@@ -160,23 +272,20 @@ describe('MPI Resolution on Write Path', () => {
     expect(response.status).toBe(200)
 
     // Verify patient was sent without a link
-    const postSpy = got.post as jest.Mock
-    const sentBundle = postSpy.mock.calls[0][1].json
+    const sentBundle = mockGotPost.mock.calls[0][1].json
     const patient = sentBundle.entry[0].resource
     expect(patient.link).toBeUndefined()
   })
 
   it('writes patient successfully when CR is unavailable (graceful failure)', async () => {
-    // Mock CR lookup throws (timeout/network error)
-    jest.spyOn(got, 'get').mockReturnValue({
+    mockGotGet.mockReturnValue({
       json: () => Promise.reject(new Error('ECONNREFUSED')),
-    } as any)
+    })
 
-    // Mock HAPI FHIR write succeeds
-    jest.spyOn(got, 'post').mockResolvedValue({
+    mockGotPost.mockResolvedValue({
       statusCode: 200,
       body: JSON.stringify({ resourceType: 'Bundle', type: 'transaction-response' }),
-    } as any)
+    })
 
     const bundle = makePatientBundle(patientWithIdentifiers)
     const response = await request(app).post('/').send(bundle)
@@ -185,27 +294,26 @@ describe('MPI Resolution on Write Path', () => {
     expect(response.status).toBe(200)
 
     // Patient should be saved without a link
-    const postSpy = got.post as jest.Mock
-    const sentBundle = postSpy.mock.calls[0][1].json
+    const sentBundle = mockGotPost.mock.calls[0][1].json
     const patient = sentBundle.entry[0].resource
     expect(patient.link).toBeUndefined()
   })
 
   it('tries remaining identifiers when first lookup fails', async () => {
-    const getSpy = jest.spyOn(got, 'get')
+    mockGotGet
       // First identifier lookup fails
       .mockReturnValueOnce({
         json: () => Promise.reject(new Error('timeout on first identifier')),
-      } as any)
+      })
       // Second identifier lookup succeeds with golden record
       .mockReturnValueOnce({
         json: () => Promise.resolve(crResponseWithGoldenRecord),
-      } as any)
+      })
 
-    jest.spyOn(got, 'post').mockResolvedValue({
+    mockGotPost.mockResolvedValue({
       statusCode: 200,
       body: JSON.stringify({ resourceType: 'Bundle', type: 'transaction-response' }),
-    } as any)
+    })
 
     const bundle = makePatientBundle(patientWithIdentifiers)
     const response = await request(app).post('/').send(bundle)
@@ -213,14 +321,13 @@ describe('MPI Resolution on Write Path', () => {
     expect(response.status).toBe(200)
 
     // Both identifiers should have been tried
-    expect(getSpy).toHaveBeenCalledTimes(2)
+    expect(mockGotGet).toHaveBeenCalledTimes(2)
 
     // Patient should have the golden record link from the second lookup
-    const postSpy = got.post as jest.Mock
-    const sentBundle = postSpy.mock.calls[0][1].json
+    const sentBundle = mockGotPost.mock.calls[0][1].json
     const patient = sentBundle.entry[0].resource
     expect(patient.link).toContainEqual({
-      other: { reference: `Patient/${goldenRecordId}` },
+      other: { reference: `Patient/${GOLDEN_RECORD_ID}` },
       type: 'refer',
     })
   })
@@ -228,37 +335,34 @@ describe('MPI Resolution on Write Path', () => {
   it('does not duplicate link if already present', async () => {
     const patientWithExistingLink = {
       ...patientWithIdentifiers,
-      link: [{ other: { reference: `Patient/${goldenRecordId}` }, type: 'refer' }],
+      link: [{ other: { reference: `Patient/${GOLDEN_RECORD_ID}` }, type: 'refer' }],
     }
 
-    jest.spyOn(got, 'get').mockReturnValue({
+    mockGotGet.mockReturnValue({
       json: () => Promise.resolve(crResponseWithGoldenRecord),
-    } as any)
+    })
 
-    jest.spyOn(got, 'post').mockResolvedValue({
+    mockGotPost.mockResolvedValue({
       statusCode: 200,
       body: JSON.stringify({ resourceType: 'Bundle', type: 'transaction-response' }),
-    } as any)
+    })
 
     const bundle = makePatientBundle(patientWithExistingLink)
     const response = await request(app).post('/').send(bundle)
 
     expect(response.status).toBe(200)
 
-    const postSpy = got.post as jest.Mock
-    const sentBundle = postSpy.mock.calls[0][1].json
+    const sentBundle = mockGotPost.mock.calls[0][1].json
     const patient = sentBundle.entry[0].resource
     // Should still have exactly one link, not two
     expect(patient.link).toHaveLength(1)
   })
 
   it('skips MPI resolution for non-Patient resources', async () => {
-    const getSpy = jest.spyOn(got, 'get')
-
-    jest.spyOn(got, 'post').mockResolvedValue({
+    mockGotPost.mockResolvedValue({
       statusCode: 200,
       body: JSON.stringify({ resourceType: 'Bundle', type: 'transaction-response' }),
-    } as any)
+    })
 
     const bundle = {
       resourceType: 'Bundle',
@@ -275,6 +379,6 @@ describe('MPI Resolution on Write Path', () => {
 
     expect(response.status).toBe(200)
     // CR should not be queried for Observations
-    expect(getSpy).not.toHaveBeenCalled()
+    expect(mockGotGet).not.toHaveBeenCalled()
   })
 })

--- a/src/routes/__tests__/fhir.test.ts
+++ b/src/routes/__tests__/fhir.test.ts
@@ -2,6 +2,7 @@ import request from 'supertest'
 import express from 'express'
 import { router } from '../fhir'
 import { saveResource } from '../fhir'
+import { invalidBundle, emptyBundle, emptyBundleResponse } from '../../lib/helpers'
 
 const app = express()
 app.use(express.json())
@@ -380,5 +381,109 @@ describe('MPI Resolution on Bundle Write Path', () => {
     expect(response.status).toBe(200)
     // CR should not be queried for Observations
     expect(mockGotGet).not.toHaveBeenCalled()
+  })
+})
+
+describe('invalidBundle', () => {
+  it('rejects null', () => {
+    expect(invalidBundle(null)).toBe(true)
+  })
+
+  it('rejects undefined', () => {
+    expect(invalidBundle(undefined)).toBe(true)
+  })
+
+  it('rejects non-object (string)', () => {
+    expect(invalidBundle('not a bundle')).toBe(true)
+  })
+
+  it('rejects non-object (number)', () => {
+    expect(invalidBundle(42)).toBe(true)
+  })
+
+  it('rejects array', () => {
+    expect(invalidBundle([{ resourceType: 'Bundle' }])).toBe(true)
+  })
+
+  it('rejects missing resourceType', () => {
+    expect(invalidBundle({})).toBe(true)
+  })
+
+  it('rejects non-Bundle resourceType', () => {
+    expect(invalidBundle({ resourceType: 'Patient' })).toBe(true)
+  })
+
+  it('rejects non-array entry (object)', () => {
+    expect(invalidBundle({ resourceType: 'Bundle', entry: {} })).toBe(true)
+  })
+
+  it('rejects non-array entry (string)', () => {
+    expect(invalidBundle({ resourceType: 'Bundle', entry: 'not an array' })).toBe(true)
+  })
+
+  it('accepts Bundle with entries', () => {
+    expect(invalidBundle({ resourceType: 'Bundle', entry: [{ resource: {} }] })).toBe(false)
+  })
+
+  it('accepts Bundle without entry property (empty bundle is valid)', () => {
+    expect(invalidBundle({ resourceType: 'Bundle', type: 'transaction' })).toBe(false)
+  })
+
+  it('accepts Bundle with empty entry array', () => {
+    expect(invalidBundle({ resourceType: 'Bundle', entry: [] })).toBe(false)
+  })
+})
+
+describe('emptyBundle', () => {
+  it('returns true when entry is undefined', () => {
+    expect(emptyBundle({ resourceType: 'Bundle', type: 'transaction' })).toBe(true)
+  })
+
+  it('returns true when entry is empty array', () => {
+    expect(emptyBundle({ resourceType: 'Bundle', entry: [] })).toBe(true)
+  })
+
+  it('returns false when entry has items', () => {
+    expect(emptyBundle({ resourceType: 'Bundle', entry: [{ resource: {} }] })).toBe(false)
+  })
+})
+
+describe('emptyBundleResponse', () => {
+  it('returns a transaction-response Bundle', () => {
+    const resp = emptyBundleResponse()
+    expect(resp.resourceType).toBe('Bundle')
+    expect(resp.type).toBe('transaction-response')
+    expect(resp.entry).toEqual([])
+  })
+})
+
+describe('POST / bundle endpoint', () => {
+  it('returns 400 for non-Bundle resource', async () => {
+    const response = await request(app)
+      .post('/')
+      .send({ resourceType: 'Patient', id: '123' })
+
+    expect(response.status).toBe(400)
+    expect(response.body.issue[0].diagnostics).toBe('Invalid bundle submitted')
+  })
+
+  it('returns 200 with empty response for empty bundle', async () => {
+    const response = await request(app)
+      .post('/')
+      .send({ resourceType: 'Bundle', type: 'transaction' })
+
+    expect(response.status).toBe(200)
+    expect(response.body.resourceType).toBe('Bundle')
+    expect(response.body.type).toBe('transaction-response')
+    expect(response.body.entry).toEqual([])
+  })
+
+  it('returns 200 with empty response for bundle with empty entry array', async () => {
+    const response = await request(app)
+      .post('/')
+      .send({ resourceType: 'Bundle', type: 'transaction', entry: [] })
+
+    expect(response.status).toBe(200)
+    expect(response.body.type).toBe('transaction-response')
   })
 })

--- a/src/routes/__tests__/fhir.test.ts
+++ b/src/routes/__tests__/fhir.test.ts
@@ -128,7 +128,7 @@ describe('MPI Resolution on Write Path', () => {
 
     // Verify the CR was queried
     expect(getSpy).toHaveBeenCalled()
-    const crCallUrl = getSpy.mock.calls[0][0] as string
+    const crCallUrl = String(getSpy.mock.calls[0][0])
     expect(crCallUrl).toContain('CR/fhir/Patient?identifier=')
 
     // Verify the patient sent to HAPI FHIR has the golden record link

--- a/src/routes/__tests__/fhir.test.ts
+++ b/src/routes/__tests__/fhir.test.ts
@@ -5,7 +5,22 @@ import got from 'got'
 import { saveResource } from '../fhir'
 
 const app = express()
+app.use(express.json())
 app.use('/', router)
+
+// Mock config
+jest.mock('../../lib/config', () => ({
+  get: (key: string) => {
+    const values: any = {
+      'fhirServer:baseURL': 'http://hapi-fhir:8080/fhir',
+      'fhirServer:username': 'hapi',
+      'fhirServer:password': 'hapi',
+      'clientRegistryUrl': 'http://openhim-core:5001/CR/fhir',
+      'mpiLookupTimeoutMs': 5000,
+    }
+    return values[key] || ''
+  },
+}))
 
 describe('FHIR Routes', () => {
   it.skip('should return 200 OK for GET /metadata', async () => {
@@ -22,23 +37,244 @@ describe('FHIR Routes', () => {
 
 it('should return 500 Internal Server Error when the post request fails', async () => {
   const req = {
-    body: {
-
-    },
+    body: {},
     params: {
       resourceType: 'Observation',
       id: '123',
     },
+    method: 'POST',
   }
   const res = {
     status: jest.fn().mockReturnThis(),
     json: jest.fn(),
   }
 
-  // Mock the post request to fail
   jest.spyOn(got, 'post').mockRejectedValue(new Error('Post request failed'))
 
   await saveResource(req, res)
 
   expect(res.status).toHaveBeenCalledWith(400)
+})
+
+describe('MPI Resolution on Write Path', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  const goldenRecordId = 'b8115fb4-ea19-4578-bc50-05d4a17ca0c7'
+
+  const makePatientBundle = (patient: any) => ({
+    resourceType: 'Bundle',
+    type: 'transaction',
+    entry: [
+      {
+        resource: patient,
+        request: { method: 'PUT', url: `Patient/${patient.id}` },
+      },
+    ],
+  })
+
+  const patientWithIdentifiers = {
+    resourceType: 'Patient',
+    id: 'abc-123',
+    name: [{ family: 'Baptiste', given: ['Jean'] }],
+    identifier: [
+      { system: 'http://isanteplus.org/openmrs/fhir2/3-isanteplus-id', value: '07D6MD' },
+      { system: 'http://isanteplus.org/openmrs/fhir2/5-code-national', value: '12345' },
+    ],
+  }
+
+  const crResponseWithGoldenRecord = {
+    resourceType: 'Bundle',
+    entry: [
+      {
+        resource: {
+          resourceType: 'Patient',
+          id: 'abc-123',
+          meta: { tag: [{ code: 'some-other-code' }] },
+        },
+      },
+      {
+        resource: {
+          resourceType: 'Patient',
+          id: goldenRecordId,
+          meta: { tag: [{ code: '5c827da5-4858-4f3d-a50c-62ece001efea' }] },
+        },
+      },
+    ],
+  }
+
+  const crResponseNoMatch = {
+    resourceType: 'Bundle',
+    entry: [],
+  }
+
+  it('adds Patient.link to golden record when CR finds a match', async () => {
+    // Mock CR lookup returns golden record
+    const getSpy = jest.spyOn(got, 'get').mockReturnValue({
+      json: () => Promise.resolve(crResponseWithGoldenRecord),
+    } as any)
+
+    // Mock HAPI FHIR write succeeds
+    jest.spyOn(got, 'post').mockResolvedValue({
+      statusCode: 200,
+      body: JSON.stringify({ resourceType: 'Bundle', type: 'transaction-response' }),
+    } as any)
+
+    const bundle = makePatientBundle(patientWithIdentifiers)
+    const response = await request(app).post('/').send(bundle)
+
+    expect(response.status).toBe(200)
+
+    // Verify the CR was queried
+    expect(getSpy).toHaveBeenCalled()
+    const crCallUrl = getSpy.mock.calls[0][0] as string
+    expect(crCallUrl).toContain('CR/fhir/Patient?identifier=')
+
+    // Verify the patient sent to HAPI FHIR has the golden record link
+    const postSpy = got.post as jest.Mock
+    const sentBundle = postSpy.mock.calls[0][1].json
+    const patient = sentBundle.entry[0].resource
+    expect(patient.link).toBeDefined()
+    expect(patient.link).toContainEqual({
+      other: { reference: `Patient/${goldenRecordId}` },
+      type: 'refer',
+    })
+  })
+
+  it('writes patient without link when CR finds no match', async () => {
+    // Mock CR lookup returns no match
+    jest.spyOn(got, 'get').mockReturnValue({
+      json: () => Promise.resolve(crResponseNoMatch),
+    } as any)
+
+    // Mock HAPI FHIR write succeeds
+    jest.spyOn(got, 'post').mockResolvedValue({
+      statusCode: 200,
+      body: JSON.stringify({ resourceType: 'Bundle', type: 'transaction-response' }),
+    } as any)
+
+    const bundle = makePatientBundle(patientWithIdentifiers)
+    const response = await request(app).post('/').send(bundle)
+
+    expect(response.status).toBe(200)
+
+    // Verify patient was sent without a link
+    const postSpy = got.post as jest.Mock
+    const sentBundle = postSpy.mock.calls[0][1].json
+    const patient = sentBundle.entry[0].resource
+    expect(patient.link).toBeUndefined()
+  })
+
+  it('writes patient successfully when CR is unavailable (graceful failure)', async () => {
+    // Mock CR lookup throws (timeout/network error)
+    jest.spyOn(got, 'get').mockReturnValue({
+      json: () => Promise.reject(new Error('ECONNREFUSED')),
+    } as any)
+
+    // Mock HAPI FHIR write succeeds
+    jest.spyOn(got, 'post').mockResolvedValue({
+      statusCode: 200,
+      body: JSON.stringify({ resourceType: 'Bundle', type: 'transaction-response' }),
+    } as any)
+
+    const bundle = makePatientBundle(patientWithIdentifiers)
+    const response = await request(app).post('/').send(bundle)
+
+    // Write should still succeed
+    expect(response.status).toBe(200)
+
+    // Patient should be saved without a link
+    const postSpy = got.post as jest.Mock
+    const sentBundle = postSpy.mock.calls[0][1].json
+    const patient = sentBundle.entry[0].resource
+    expect(patient.link).toBeUndefined()
+  })
+
+  it('tries remaining identifiers when first lookup fails', async () => {
+    const getSpy = jest.spyOn(got, 'get')
+      // First identifier lookup fails
+      .mockReturnValueOnce({
+        json: () => Promise.reject(new Error('timeout on first identifier')),
+      } as any)
+      // Second identifier lookup succeeds with golden record
+      .mockReturnValueOnce({
+        json: () => Promise.resolve(crResponseWithGoldenRecord),
+      } as any)
+
+    jest.spyOn(got, 'post').mockResolvedValue({
+      statusCode: 200,
+      body: JSON.stringify({ resourceType: 'Bundle', type: 'transaction-response' }),
+    } as any)
+
+    const bundle = makePatientBundle(patientWithIdentifiers)
+    const response = await request(app).post('/').send(bundle)
+
+    expect(response.status).toBe(200)
+
+    // Both identifiers should have been tried
+    expect(getSpy).toHaveBeenCalledTimes(2)
+
+    // Patient should have the golden record link from the second lookup
+    const postSpy = got.post as jest.Mock
+    const sentBundle = postSpy.mock.calls[0][1].json
+    const patient = sentBundle.entry[0].resource
+    expect(patient.link).toContainEqual({
+      other: { reference: `Patient/${goldenRecordId}` },
+      type: 'refer',
+    })
+  })
+
+  it('does not duplicate link if already present', async () => {
+    const patientWithExistingLink = {
+      ...patientWithIdentifiers,
+      link: [{ other: { reference: `Patient/${goldenRecordId}` }, type: 'refer' }],
+    }
+
+    jest.spyOn(got, 'get').mockReturnValue({
+      json: () => Promise.resolve(crResponseWithGoldenRecord),
+    } as any)
+
+    jest.spyOn(got, 'post').mockResolvedValue({
+      statusCode: 200,
+      body: JSON.stringify({ resourceType: 'Bundle', type: 'transaction-response' }),
+    } as any)
+
+    const bundle = makePatientBundle(patientWithExistingLink)
+    const response = await request(app).post('/').send(bundle)
+
+    expect(response.status).toBe(200)
+
+    const postSpy = got.post as jest.Mock
+    const sentBundle = postSpy.mock.calls[0][1].json
+    const patient = sentBundle.entry[0].resource
+    // Should still have exactly one link, not two
+    expect(patient.link).toHaveLength(1)
+  })
+
+  it('skips MPI resolution for non-Patient resources', async () => {
+    const getSpy = jest.spyOn(got, 'get')
+
+    jest.spyOn(got, 'post').mockResolvedValue({
+      statusCode: 200,
+      body: JSON.stringify({ resourceType: 'Bundle', type: 'transaction-response' }),
+    } as any)
+
+    const bundle = {
+      resourceType: 'Bundle',
+      type: 'transaction',
+      entry: [
+        {
+          resource: { resourceType: 'Observation', id: 'obs-1', status: 'final' },
+          request: { method: 'PUT', url: 'Observation/obs-1' },
+        },
+      ],
+    }
+
+    const response = await request(app).post('/').send(bundle)
+
+    expect(response.status).toBe(200)
+    // CR should not be queried for Observations
+    expect(getSpy).not.toHaveBeenCalled()
+  })
 })

--- a/src/routes/fhir.ts
+++ b/src/routes/fhir.ts
@@ -97,15 +97,18 @@ async function resolvePatientMpi(patient: any): Promise<any> {
 /**
  * Enrich a FHIR Bundle by resolving Patient resources against the MPI.
  * Non-Patient resources are passed through unchanged.
+ * Patient lookups run in parallel to minimize write-path latency.
  */
 async function enrichBundleWithMpi(bundle: any): Promise<any> {
   if (!bundle || !bundle.entry) return bundle
 
-  for (const entry of bundle.entry) {
+  const resolutions = bundle.entry.map(async (entry: any) => {
     if (entry.resource && entry.resource.resourceType === 'Patient') {
       entry.resource = await resolvePatientMpi(entry.resource)
     }
-  }
+  })
+
+  await Promise.allSettled(resolutions)
 
   return bundle
 }

--- a/src/routes/fhir.ts
+++ b/src/routes/fhir.ts
@@ -101,8 +101,6 @@ async function resolvePatientMpi(patient: any): Promise<any> {
  * Enrich a FHIR Bundle by resolving Patient resources against the MPI.
  * Non-Patient resources are passed through unchanged.
  * Processes patients in batches of MPI_CONCURRENCY to avoid overwhelming the CR.
- * Caches lookup results within the request to avoid duplicate CR calls for
- * patients sharing the same identifiers.
  */
 const MPI_CONCURRENCY = 5
 

--- a/src/routes/fhir.ts
+++ b/src/routes/fhir.ts
@@ -27,26 +27,24 @@ async function resolvePatientMpi(patient: any): Promise<any> {
     return patient
   }
 
-  try {
-    // Search CR by patient identifiers
-    const identifiers = patient.identifier || []
-    let goldenRecordId: string | null = null
+  const identifiers = patient.identifier || []
+  let goldenRecordId: string | null = null
 
-    for (const identifier of identifiers) {
-      if (!identifier.system || !identifier.value) continue
+  const options = {
+    username: config.get('fhirServer:username'),
+    password: config.get('fhirServer:password'),
+  }
 
+  for (const identifier of identifiers) {
+    if (!identifier.system || !identifier.value) continue
+
+    try {
       const searchUrl = `${crUrl}/Patient?identifier=${encodeURIComponent(identifier.system)}|${encodeURIComponent(identifier.value)}&_include=Patient:link`
       logger.info(`MPI lookup: ${identifier.system}|${identifier.value}`)
-
-      const options = {
-        username: config.get('fhirServer:username'),
-        password: config.get('fhirServer:password'),
-      }
 
       const response: any = await got.get(searchUrl, options).json()
 
       if (response && response.entry) {
-        // Find the golden record (tagged with the golden record code)
         for (const entry of response.entry) {
           const resource = entry.resource
           if (
@@ -62,30 +60,29 @@ async function resolvePatientMpi(patient: any): Promise<any> {
       }
 
       if (goldenRecordId) break // Found a match, stop searching
+    } catch (error: any) {
+      // Log and continue to the next identifier
+      logger.warn(`MPI lookup failed for identifier ${identifier.system}|${identifier.value}: ${error.message}`)
     }
+  }
 
-    if (goldenRecordId) {
-      logger.info(`MPI resolved: Patient/${patient.id} → golden record ${goldenRecordId}`)
+  if (goldenRecordId) {
+    logger.info(`MPI resolved: Patient/${patient.id} → golden record ${goldenRecordId}`)
 
-      // Add link to golden record if not already present
-      if (!patient.link) patient.link = []
+    if (!patient.link) patient.link = []
 
-      const alreadyLinked = patient.link.some(
-        (l: any) => l.other && l.other.reference === `Patient/${goldenRecordId}`,
-      )
+    const alreadyLinked = patient.link.some(
+      (l: any) => l.other && l.other.reference === `Patient/${goldenRecordId}`,
+    )
 
-      if (!alreadyLinked) {
-        patient.link.push({
-          other: { reference: `Patient/${goldenRecordId}` },
-          type: 'refer',
-        })
-      }
-    } else {
-      logger.info(`MPI lookup: no golden record found for Patient/${patient.id}`)
+    if (!alreadyLinked) {
+      patient.link.push({
+        other: { reference: `Patient/${goldenRecordId}` },
+        type: 'refer',
+      })
     }
-  } catch (error: any) {
-    // MPI lookup failure should not block the write
-    logger.warn(`MPI lookup failed for Patient/${patient.id}: ${error.message}`)
+  } else {
+    logger.info(`MPI lookup: no golden record found for Patient/${patient.id}`)
   }
 
   return patient

--- a/src/routes/fhir.ts
+++ b/src/routes/fhir.ts
@@ -44,9 +44,12 @@ async function resolvePatientMpi(patient: any): Promise<any> {
   for (const identifier of identifiers) {
     if (!identifier.system || !identifier.value) continue
 
+    const idValue = String(identifier.value)
+    const maskedValue = idValue.slice(0, 3) + '***'
+
     try {
-      const searchUrl = `${crUrl}/Patient?identifier=${encodeURIComponent(identifier.system)}|${encodeURIComponent(identifier.value)}&_include=Patient:link`
-      logger.debug(`MPI lookup: ${identifier.system}|${identifier.value.substring(0, 3)}***`)
+      const searchUrl = `${crUrl}/Patient?identifier=${encodeURIComponent(identifier.system)}|${encodeURIComponent(idValue)}&_include=Patient:link`
+      logger.debug(`MPI lookup: ${identifier.system}|${maskedValue}`)
 
       const response: any = await got.get(searchUrl, options).json()
 
@@ -68,7 +71,7 @@ async function resolvePatientMpi(patient: any): Promise<any> {
       if (goldenRecordId) break // Found a match, stop searching
     } catch (error: any) {
       // Log and continue to the next identifier
-      logger.warn(`MPI lookup failed for identifier ${identifier.system}|${identifier.value.substring(0, 3)}***: ${error.message}`)
+      logger.warn(`MPI lookup failed for identifier ${identifier.system}|${maskedValue}: ${error.message}`)
     }
   }
 

--- a/src/routes/fhir.ts
+++ b/src/routes/fhir.ts
@@ -11,6 +11,102 @@ import { getMetadata } from '../lib/helpers'
 
 export const router = express.Router()
 
+const GOLDEN_RECORD_CODE = '5c827da5-4858-4f3d-a50c-62ece001efea'
+
+/**
+ * Look up a Patient's golden record (master patient ID) in the Client Registry.
+ * If found, adds a Patient.link entry pointing to the golden record.
+ * This ensures the SHR stores patients with their MPI identifier,
+ * enabling cross-facility longitudinal queries.
+ *
+ * Returns the enriched patient resource, or the original if no CR match found.
+ */
+async function resolvePatientMpi(patient: any): Promise<any> {
+  const crUrl = config.get('clientRegistryUrl')
+  if (!crUrl || !patient || patient.resourceType !== 'Patient') {
+    return patient
+  }
+
+  try {
+    // Search CR by patient identifiers
+    const identifiers = patient.identifier || []
+    let goldenRecordId: string | null = null
+
+    for (const identifier of identifiers) {
+      if (!identifier.system || !identifier.value) continue
+
+      const searchUrl = `${crUrl}/Patient?identifier=${encodeURIComponent(identifier.system)}|${encodeURIComponent(identifier.value)}&_include=Patient:link`
+      logger.info(`MPI lookup: ${identifier.system}|${identifier.value}`)
+
+      const options = {
+        username: config.get('fhirServer:username'),
+        password: config.get('fhirServer:password'),
+      }
+
+      const response: any = await got.get(searchUrl, options).json()
+
+      if (response && response.entry) {
+        // Find the golden record (tagged with the golden record code)
+        for (const entry of response.entry) {
+          const resource = entry.resource
+          if (
+            resource &&
+            resource.meta &&
+            resource.meta.tag &&
+            resource.meta.tag.some((t: any) => t.code === GOLDEN_RECORD_CODE)
+          ) {
+            goldenRecordId = resource.id
+            break
+          }
+        }
+      }
+
+      if (goldenRecordId) break // Found a match, stop searching
+    }
+
+    if (goldenRecordId) {
+      logger.info(`MPI resolved: Patient/${patient.id} → golden record ${goldenRecordId}`)
+
+      // Add link to golden record if not already present
+      if (!patient.link) patient.link = []
+
+      const alreadyLinked = patient.link.some(
+        (l: any) => l.other && l.other.reference === `Patient/${goldenRecordId}`,
+      )
+
+      if (!alreadyLinked) {
+        patient.link.push({
+          other: { reference: `Patient/${goldenRecordId}` },
+          type: 'refer',
+        })
+      }
+    } else {
+      logger.info(`MPI lookup: no golden record found for Patient/${patient.id}`)
+    }
+  } catch (error: any) {
+    // MPI lookup failure should not block the write
+    logger.warn(`MPI lookup failed for Patient/${patient.id}: ${error.message}`)
+  }
+
+  return patient
+}
+
+/**
+ * Enrich a FHIR Bundle by resolving Patient resources against the MPI.
+ * Non-Patient resources are passed through unchanged.
+ */
+async function enrichBundleWithMpi(bundle: any): Promise<any> {
+  if (!bundle || !bundle.entry) return bundle
+
+  for (const entry of bundle.entry) {
+    if (entry.resource && entry.resource.resourceType === 'Patient') {
+      entry.resource = await resolvePatientMpi(entry.resource)
+    }
+  }
+
+  return bundle
+}
+
 router.get('/', (req: Request, res: Response) => {
   return res.status(200).send(req.url)
 })
@@ -93,11 +189,11 @@ router.get('/:resource/:id?/:operation?', async (req: Request, res: Response) =>
   }
 })
 
-// Post a bundle of resources
+// Post a bundle of resources — enriched with MPI golden record links
 router.post('/', async (req, res) => {
   try {
     logger.info('Received a request to add a bundle of resources')
-    const resource = req.body
+    let resource = req.body
 
     // Verify the bundle
     if (invalidBundle(resource)) {
@@ -107,6 +203,9 @@ router.post('/', async (req, res) => {
     if (resource.entry.length === 0) {
       return res.status(400).json(invalidBundleMessage())
     }
+
+    // Resolve Patient resources against the MPI before saving
+    resource = await enrichBundleWithMpi(resource)
 
     const uri = URI(config.get('fhirServer:baseURL'))
 
@@ -137,7 +236,7 @@ router.put('/:resourceType/:id', (req: any, res: any) => {
 /** Helpers */
 
 export async function saveResource(req: any, res: any, operation?: string) {
-  const resource = req.body
+  let resource = req.body
   const resourceType = req.params.resourceType
   const id = req.params.id
   if (id && !resource.id) {
@@ -145,7 +244,12 @@ export async function saveResource(req: any, res: any, operation?: string) {
   }
 
   logger.info('Received a request to add resource type ' + resourceType + ' with id ' + id)
-  
+
+  // Resolve Patient against MPI before saving
+  if (resourceType === 'Patient') {
+    resource = await resolvePatientMpi(resource)
+  }
+
   let ret, uri, errorFromHapi
   try {
     if (req.method === 'POST') {
@@ -158,7 +262,7 @@ export async function saveResource(req: any, res: any, operation?: string) {
       return
     }
 
-    // Perform  request
+    // Perform request
     logger.info('Sending ' + req.method + ' request to ' + uri)
     ret = await got({
       method: req.method,

--- a/src/routes/fhir.ts
+++ b/src/routes/fhir.ts
@@ -269,9 +269,16 @@ export async function saveResource(req: any, res: any, operation?: string) {
 
   logger.info('Received a request to add resource type ' + resourceType + ' with id ' + id)
 
-  // Resolve Patient against MPI before saving
+  // Resolve Patient against MPI before saving, but do not block the save if MPI resolution fails.
   if (resourceType === 'Patient') {
-    resource = await resolvePatientMpi(resource)
+    try {
+      resource = await resolvePatientMpi(resource)
+    } catch (error: any) {
+      logger.warn(
+        'Failed to resolve Patient against MPI during saveResource; continuing with original resource: ' +
+          (error?.message || String(error))
+      )
+    }
   }
 
   let ret, uri, errorFromHapi

--- a/src/routes/fhir.ts
+++ b/src/routes/fhir.ts
@@ -68,7 +68,7 @@ async function resolvePatientMpi(patient: any): Promise<any> {
       if (goldenRecordId) break // Found a match, stop searching
     } catch (error: any) {
       // Log and continue to the next identifier
-      logger.warn(`MPI lookup failed for identifier ${identifier.system}|${identifier.value}: ${error.message}`)
+      logger.warn(`MPI lookup failed for identifier ${identifier.system}|${identifier.value.substring(0, 3)}***: ${error.message}`)
     }
   }
 

--- a/src/routes/fhir.ts
+++ b/src/routes/fhir.ts
@@ -13,6 +13,10 @@ export const router = express.Router()
 
 const GOLDEN_RECORD_CODE = '5c827da5-4858-4f3d-a50c-62ece001efea'
 
+// Timeout for MPI lookups — prevents slow CR from stalling SHR writes.
+// Falls back to 5 seconds if not configured.
+const MPI_LOOKUP_TIMEOUT_MS = config.get('mpiLookupTimeoutMs') || 5000
+
 /**
  * Look up a Patient's golden record (master patient ID) in the Client Registry.
  * If found, adds a Patient.link entry pointing to the golden record.
@@ -33,6 +37,8 @@ async function resolvePatientMpi(patient: any): Promise<any> {
   const options = {
     username: config.get('fhirServer:username'),
     password: config.get('fhirServer:password'),
+    timeout: { request: MPI_LOOKUP_TIMEOUT_MS },
+    retry: { limit: 1, methods: ['GET'] },
   }
 
   for (const identifier of identifiers) {
@@ -40,7 +46,7 @@ async function resolvePatientMpi(patient: any): Promise<any> {
 
     try {
       const searchUrl = `${crUrl}/Patient?identifier=${encodeURIComponent(identifier.system)}|${encodeURIComponent(identifier.value)}&_include=Patient:link`
-      logger.info(`MPI lookup: ${identifier.system}|${identifier.value}`)
+      logger.debug(`MPI lookup: ${identifier.system}|${identifier.value.substring(0, 3)}***`)
 
       const response: any = await got.get(searchUrl, options).json()
 

--- a/src/routes/fhir.ts
+++ b/src/routes/fhir.ts
@@ -3,7 +3,7 @@ import express, { Request, Response } from 'express'
 import got from 'got'
 import URI from 'urijs'
 import config from '../lib/config'
-import { getHapiPassthrough, invalidBundle, invalidBundleMessage } from '../lib/helpers'
+import { getHapiPassthrough, invalidBundle, invalidBundleMessage, emptyBundle, emptyBundleResponse } from '../lib/helpers'
 import logger from '../lib/winston'
 import { generateSimpleIpsBundle } from '../workflows/ipsWorkflows'
 import { getResourceTypeEnum, isValidResourceType } from '../lib/validate'
@@ -230,8 +230,9 @@ router.post('/', async (req, res) => {
       return res.status(400).json(invalidBundleMessage())
     }
 
-    if (resource.entry.length === 0) {
-      return res.status(400).json(invalidBundleMessage())
+    if (emptyBundle(resource)) {
+      logger.info('Received empty bundle, returning empty response')
+      return res.status(200).json(emptyBundleResponse())
     }
 
     // Resolve Patient resources against the MPI before saving

--- a/src/routes/fhir.ts
+++ b/src/routes/fhir.ts
@@ -38,7 +38,7 @@ async function resolvePatientMpi(patient: any): Promise<any> {
     username: config.get('fhirServer:username'),
     password: config.get('fhirServer:password'),
     timeout: { request: MPI_LOOKUP_TIMEOUT_MS },
-    retry: { limit: 1, methods: ['GET'] },
+    retry: { limit: 1, methods: ['GET' as const] },
   }
 
   for (const identifier of identifiers) {
@@ -102,13 +102,18 @@ async function resolvePatientMpi(patient: any): Promise<any> {
 async function enrichBundleWithMpi(bundle: any): Promise<any> {
   if (!bundle || !bundle.entry) return bundle
 
-  const resolutions = bundle.entry.map(async (entry: any) => {
+  const resolutions = bundle.entry.map((entry: any) => {
     if (entry.resource && entry.resource.resourceType === 'Patient') {
-      entry.resource = await resolvePatientMpi(entry.resource)
+      return resolvePatientMpi(entry.resource).then((resolved: any) => {
+        entry.resource = resolved
+      }).catch((err: any) => {
+        logger.warn(`MPI enrichment failed for Patient/${entry.resource.id}: ${err.message}`)
+      })
     }
+    return Promise.resolve()
   })
 
-  await Promise.allSettled(resolutions)
+  await Promise.all(resolutions)
 
   return bundle
 }

--- a/src/routes/fhir.ts
+++ b/src/routes/fhir.ts
@@ -40,8 +40,8 @@ async function resolvePatientMpi(patient: any): Promise<any> {
   let goldenRecordId: string | null = null
 
   const options = {
-    username: config.get('fhirServer:username'),
-    password: config.get('fhirServer:password'),
+    username: config.get('clientRegistryUsername') || config.get('fhirServer:username'),
+    password: config.get('clientRegistryPassword') || config.get('fhirServer:password'),
     timeout: { request: MPI_LOOKUP_TIMEOUT_MS },
     retry: { limit: 1, methods: ['GET' as const] },
   }

--- a/src/routes/fhir.ts
+++ b/src/routes/fhir.ts
@@ -97,23 +97,36 @@ async function resolvePatientMpi(patient: any): Promise<any> {
 /**
  * Enrich a FHIR Bundle by resolving Patient resources against the MPI.
  * Non-Patient resources are passed through unchanged.
- * Patient lookups run in parallel to minimize write-path latency.
+ * Processes patients in batches of MPI_CONCURRENCY to avoid overwhelming the CR.
+ * Caches lookup results within the request to avoid duplicate CR calls for
+ * patients sharing the same identifiers.
  */
+const MPI_CONCURRENCY = 5
+
 async function enrichBundleWithMpi(bundle: any): Promise<any> {
   if (!bundle || !bundle.entry) return bundle
 
-  const resolutions = bundle.entry.map((entry: any) => {
-    if (entry.resource && entry.resource.resourceType === 'Patient') {
-      return resolvePatientMpi(entry.resource).then((resolved: any) => {
-        entry.resource = resolved
-      }).catch((err: any) => {
-        logger.warn(`MPI enrichment failed for Patient/${entry.resource.id}: ${err.message}`)
-      })
-    }
-    return Promise.resolve()
-  })
+  const patientEntries = bundle.entry.filter(
+    (e: any) => e.resource && e.resource.resourceType === 'Patient',
+  )
 
-  await Promise.all(resolutions)
+  if (patientEntries.length === 0) return bundle
+
+  // Process in batches to limit concurrent CR requests
+  for (let i = 0; i < patientEntries.length; i += MPI_CONCURRENCY) {
+    const batch = patientEntries.slice(i, i + MPI_CONCURRENCY)
+    await Promise.all(
+      batch.map((entry: any) =>
+        resolvePatientMpi(entry.resource)
+          .then((resolved: any) => {
+            entry.resource = resolved
+          })
+          .catch((err: any) => {
+            logger.warn(`MPI enrichment failed for Patient/${entry.resource.id}: ${err.message}`)
+          }),
+      ),
+    )
+  }
 
   return bundle
 }

--- a/src/routes/fhir.ts
+++ b/src/routes/fhir.ts
@@ -11,11 +11,16 @@ import { getMetadata } from '../lib/helpers'
 
 export const router = express.Router()
 
-const GOLDEN_RECORD_CODE = '5c827da5-4858-4f3d-a50c-62ece001efea'
+const GOLDEN_RECORD_CODE = config.get('goldenRecordCode') || '5c827da5-4858-4f3d-a50c-62ece001efea'
 
 // Timeout for MPI lookups — prevents slow CR from stalling SHR writes.
-// Falls back to 5 seconds if not configured.
-const MPI_LOOKUP_TIMEOUT_MS = config.get('mpiLookupTimeoutMs') || 5000
+// Falls back to 5 seconds if not configured or invalid.
+const rawMpiLookupTimeoutMs = config.get('mpiLookupTimeoutMs')
+const parsedMpiLookupTimeoutMs = Number(rawMpiLookupTimeoutMs)
+const MPI_LOOKUP_TIMEOUT_MS =
+  rawMpiLookupTimeoutMs === undefined || rawMpiLookupTimeoutMs === null || Number.isNaN(parsedMpiLookupTimeoutMs)
+    ? 5000
+    : parsedMpiLookupTimeoutMs
 
 /**
  * Look up a Patient's golden record (master patient ID) in the Client Registry.
@@ -31,7 +36,7 @@ async function resolvePatientMpi(patient: any): Promise<any> {
     return patient
   }
 
-  const identifiers = patient.identifier || []
+  const identifiers = patient.identifier ? (Array.isArray(patient.identifier) ? patient.identifier  :  [patient.identifier]): []
   let goldenRecordId: string | null = null
 
   const options = {

--- a/src/routes/lab-bw.ts
+++ b/src/routes/lab-bw.ts
@@ -3,7 +3,7 @@
 import { R4 } from '@ahryman40k/ts-fhir-types'
 import express, { Request, Response } from 'express'
 import { saveBundle } from '../hapi/lab'
-import { getMetadata, invalidBundle, invalidBundleMessage } from '../lib/helpers'
+import { getMetadata, invalidBundle, invalidBundleMessage, emptyBundle, emptyBundleResponse } from '../lib/helpers'
 import logger from '../lib/winston'
 import { WorkflowHandler } from '../workflows/botswana/workflowHandler'
 
@@ -31,6 +31,10 @@ router.all('/', async (req: Request, res: Response) => {
       // Validate Bundle
       if (invalidBundle(orderBundle)) {
         return res.status(400).json(invalidBundleMessage())
+      }
+
+      if (emptyBundle(orderBundle)) {
+        return res.status(200).json(emptyBundleResponse())
       }
 
       // Save Bundle

--- a/src/routes/lab.ts
+++ b/src/routes/lab.ts
@@ -3,7 +3,7 @@ import { R4 } from '@ahryman40k/ts-fhir-types'
 import express, { Request, Response } from 'express'
 import got from 'got/dist/source'
 import { saveBundle } from '../hapi/lab'
-import { getMetadata, invalidBundle, invalidBundleMessage } from '../lib/helpers'
+import { getMetadata, invalidBundle, invalidBundleMessage, emptyBundle, emptyBundleResponse } from '../lib/helpers'
 import logger from '../lib/winston'
 import { LabWorkflows } from '../workflows/labWorkflows'
 
@@ -29,6 +29,10 @@ router.all('/', async (req: Request, res: Response) => {
     // Validate Bundle
     if (invalidBundle(orderBundle)) {
       return res.status(400).json(invalidBundleMessage())
+    }
+
+    if (emptyBundle(orderBundle)) {
+      return res.status(200).json(emptyBundleResponse())
     }
 
     let resultBundle: R4.IBundle


### PR DESCRIPTION
## Problem
The `resolvePatientMpi` function queries the Client Registry (OpenCR) via OpenHIM to find golden records. The CR channel in OpenHIM requires an authenticated client, but the code uses `fhirServer:username`/`fhirServer:password` — which are credentials for the internal HAPI FHIR store and may not be configured or authorized on the CR channel.

This results in `401 Unauthorized` on every MPI lookup:
```
MPI lookup failed for identifier ...: Response code 401 (Unauthorized)
```

## Fix
Use `clientRegistryUsername`/`clientRegistryPassword` from config for CR queries, falling back to `fhirServer` credentials if not set. This allows deployments to configure separate credentials for the CR channel without affecting HAPI FHIR access.

Depends on #115 (MPI resolution on write path).

## Test plan
- [x] Configured `clientRegistryUsername`/`clientRegistryPassword` in SHR mediator config
- [x] MPI lookups now authenticate successfully — golden records resolved for both patients
- [x] Verified `Patient.link[type=refer]` present in SHR HAPI FHIR store