### PR TITLE
Address PR #119 review feedback on helpers.ts

### DIFF
--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -8,7 +8,7 @@ export function invalidBundle(resource: any): boolean {
   if (!resource || typeof resource !== 'object' || Array.isArray(resource)) {
     return true
   }
-  if (resource.resourceType !== 'Bundle') {
+  if (!('resourceType' in resource) || resource.resourceType !== 'Bundle') {
     return true
   }
   if ('entry' in resource && !Array.isArray(resource.entry)) {
@@ -21,7 +21,7 @@ export function emptyBundle(resource: any): boolean {
   return !Array.isArray(resource.entry) || resource.entry.length === 0
 }
 
-export function emptyBundleResponse(): any {
+export function emptyBundleResponse() {
   return { resourceType: 'Bundle', type: 'transaction-response', entry: [] }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #119 — addresses outstanding review comments:

- **Remove explicit `any` return type from `emptyBundleResponse()`** ([review comment](https://github.com/DIGI-UW/shared-health-record/pull/119#discussion_r3039477686)): TypeScript can infer the return type from the object literal
- **Guard `invalidBundle` against missing `resourceType` property** ([review comment](https://github.com/DIGI-UW/shared-health-record/pull/119#discussion_r3039481889)): Use `'resourceType' in resource` check before comparing its value, so objects without the property are correctly rejected