### PR TITLE
Return correct bundle response type for batch vs transaction

### DIFF
--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -21,8 +21,14 @@ export function emptyBundle(resource: any): boolean {
   return !Array.isArray(resource.entry) || resource.entry.length === 0
 }
 
-export function emptyBundleResponse() {
-  return { resourceType: 'Bundle', type: 'transaction-response', entry: [] }
+export function emptyBundleResponse(resource?: any) {
+  const bundleType = resource?.type === 'batch'
+    ? 'batch-response'
+    : resource?.type === 'transaction'
+      ? 'transaction-response'
+      : 'transaction-response'
+
+  return { resourceType: 'Bundle', type: bundleType, entry: [] }
 }
 
 export function invalidBundleMessage(): any {

--- a/src/routes/fhir.ts
+++ b/src/routes/fhir.ts
@@ -232,7 +232,7 @@ router.post('/', async (req, res) => {
 
     if (emptyBundle(resource)) {
       logger.info('Received empty bundle, returning empty response')
-      return res.status(200).json(emptyBundleResponse())
+      return res.status(200).json(emptyBundleResponse(resource))
     }
 
     // Resolve Patient resources against the MPI before saving

--- a/src/routes/lab-bw.ts
+++ b/src/routes/lab-bw.ts
@@ -34,7 +34,7 @@ router.all('/', async (req: Request, res: Response) => {
       }
 
       if (emptyBundle(orderBundle)) {
-        return res.status(200).json(emptyBundleResponse())
+        return res.status(200).json(emptyBundleResponse(orderBundle))
       }
 
       // Save Bundle

--- a/src/routes/lab.ts
+++ b/src/routes/lab.ts
@@ -32,7 +32,7 @@ router.all('/', async (req: Request, res: Response) => {
     }
 
     if (emptyBundle(orderBundle)) {
-      return res.status(200).json(emptyBundleResponse())
+      return res.status(200).json(emptyBundleResponse(orderBundle))
     }
 
     let resultBundle: R4.IBundle


### PR DESCRIPTION
## Summary

Follow-up to [#119 review comment](https://github.com/DIGI-UW/shared-health-record/pull/119#discussion_r3038691338).

`emptyBundleResponse()` always returned a `transaction-response` Bundle regardless of the input bundle type. This is incorrect per FHIR conventions when a `batch` bundle is posted.

- `emptyBundleResponse` now accepts the request bundle and returns the corresponding `*-response` type (`batch-response` or `transaction-response`)
- Updated all call sites (`fhir.ts`, `lab.ts`, `lab-bw.ts`) to pass the resource through