### PR TITLE
Fix cross-facility patient data visibility via golden record normalization

### DIFF
--- a/src/routes/__tests__/fhir.test.ts
+++ b/src/routes/__tests__/fhir.test.ts
@@ -2,7 +2,7 @@ import request from 'supertest'
 import express from 'express'
 import { router } from '../fhir'
 import { saveResource } from '../fhir'
-import { invalidBundle, emptyBundle, emptyBundleResponse } from '../../lib/helpers'
+import { emptyBundle, emptyBundleResponse, invalidBundle } from '../../lib/helpers'
 
 const app = express()
 app.use(express.json())
@@ -11,12 +11,14 @@ app.use('/', router)
 // Mock got at module level so all methods are available for spying
 const mockGotGet = jest.fn()
 const mockGotPost = jest.fn()
+const mockGotPut = jest.fn()
 const mockGotDefault = jest.fn()
 
 jest.mock('got', () => {
   const fn = (...args: any[]) => mockGotDefault(...args)
   fn.get = (...args: any[]) => mockGotGet(...args)
   fn.post = (...args: any[]) => mockGotPost(...args)
+  fn.put = (...args: any[]) => mockGotPut(...args)
   return { __esModule: true, default: fn }
 })
 
@@ -454,6 +456,298 @@ describe('emptyBundleResponse', () => {
     expect(resp.resourceType).toBe('Bundle')
     expect(resp.type).toBe('transaction-response')
     expect(resp.entry).toEqual([])
+  })
+})
+
+describe('Reference Rewriting on Bundle Write Path', () => {
+  afterEach(() => {
+    mockGotGet.mockReset()
+    mockGotPost.mockReset()
+    mockGotPut.mockReset()
+    mockGotDefault.mockReset()
+  })
+
+  const crResponseWithSources = {
+    resourceType: 'Bundle',
+    entry: [
+      {
+        resource: {
+          resourceType: 'Patient',
+          id: 'source-hueh',
+          name: [{ use: 'official', family: 'OJOK', given: ['OWITO'] }],
+          gender: 'male',
+          birthDate: '1997',
+          meta: { tag: [{ code: 'hueh' }], lastUpdated: '2026-04-10T07:08:57Z' },
+          identifier: [{ system: 'http://isanteplus.org/openmrs/fhir2/3-isanteplus-id', value: '03N3AN' }],
+        },
+      },
+      {
+        resource: {
+          resourceType: 'Patient',
+          id: GOLDEN_RECORD_ID,
+          meta: { tag: [{ code: GOLDEN_RECORD_CODE }] },
+        },
+      },
+    ],
+  }
+
+  it('rewrites clinical resource patient references to golden record ID', async () => {
+    mockGotGet.mockReturnValue({
+      json: () => Promise.resolve(crResponseWithSources),
+    })
+
+    // Mock the golden record PUT (background update)
+    mockGotPut.mockResolvedValue({ statusCode: 200, body: '{}' })
+
+    mockGotPost.mockResolvedValue({
+      statusCode: 200,
+      body: JSON.stringify({ resourceType: 'Bundle', type: 'transaction-response' }),
+    })
+
+    const bundle = {
+      resourceType: 'Bundle',
+      type: 'transaction',
+      entry: [
+        {
+          resource: {
+            resourceType: 'Patient',
+            id: 'pt-facility-1',
+            identifier: [{ system: 'http://isanteplus.org/openmrs/fhir2/5-code-national', value: '45678' }],
+          },
+          request: { method: 'PUT', url: 'Patient/pt-facility-1' },
+        },
+        {
+          resource: {
+            resourceType: 'AllergyIntolerance',
+            id: 'allergy-1',
+            patient: { reference: 'Patient/pt-facility-1' },
+            code: { text: 'Penicillin' },
+          },
+          request: { method: 'PUT', url: 'AllergyIntolerance/allergy-1' },
+        },
+        {
+          resource: {
+            resourceType: 'Observation',
+            id: 'obs-1',
+            subject: { reference: 'Patient/pt-facility-1' },
+            status: 'final',
+          },
+          request: { method: 'PUT', url: 'Observation/obs-1' },
+        },
+      ],
+    }
+
+    const response = await request(app).post('/').send(bundle)
+    expect(response.status).toBe(200)
+
+    const sentBundle = mockGotPost.mock.calls[0][1].json
+
+    // Patient should have golden record link
+    const patient = sentBundle.entry[0].resource
+    expect(patient.link).toContainEqual({
+      other: { reference: `Patient/${GOLDEN_RECORD_ID}` },
+      type: 'refer',
+    })
+
+    // AllergyIntolerance.patient should be rewritten to golden record
+    const allergy = sentBundle.entry[1].resource
+    expect(allergy.patient.reference).toBe(`Patient/${GOLDEN_RECORD_ID}`)
+
+    // Observation.subject should be rewritten to golden record
+    const obs = sentBundle.entry[2].resource
+    expect(obs.subject.reference).toBe(`Patient/${GOLDEN_RECORD_ID}`)
+  })
+
+  it('rewrites nested patient references via recursive traversal', async () => {
+    mockGotGet.mockReturnValue({
+      json: () => Promise.resolve(crResponseWithSources),
+    })
+
+    mockGotPut.mockResolvedValue({ statusCode: 200, body: '{}' })
+
+    mockGotPost.mockResolvedValue({
+      statusCode: 200,
+      body: JSON.stringify({ resourceType: 'Bundle', type: 'transaction-response' }),
+    })
+
+    const bundle = {
+      resourceType: 'Bundle',
+      type: 'transaction',
+      entry: [
+        {
+          resource: {
+            resourceType: 'Patient',
+            id: 'pt-nested',
+            identifier: [{ system: 'http://isanteplus.org/openmrs/fhir2/5-code-national', value: '99999' }],
+          },
+          request: { method: 'PUT', url: 'Patient/pt-nested' },
+        },
+        {
+          resource: {
+            resourceType: 'Encounter',
+            id: 'enc-1',
+            subject: { reference: 'Patient/pt-nested' },
+            participant: [
+              {
+                individual: { reference: 'Practitioner/prac-1' },
+              },
+            ],
+            serviceProvider: { reference: 'Organization/org-1' },
+          },
+          request: { method: 'PUT', url: 'Encounter/enc-1' },
+        },
+      ],
+    }
+
+    const response = await request(app).post('/').send(bundle)
+    expect(response.status).toBe(200)
+
+    const sentBundle = mockGotPost.mock.calls[0][1].json
+    const encounter = sentBundle.entry[1].resource
+
+    // subject should be rewritten
+    expect(encounter.subject.reference).toBe(`Patient/${GOLDEN_RECORD_ID}`)
+    // Practitioner reference should NOT be rewritten (not a Patient ref)
+    expect(encounter.participant[0].individual.reference).toBe('Practitioner/prac-1')
+  })
+
+  it('does not rewrite references when no golden record is found', async () => {
+    mockGotGet.mockReturnValue({
+      json: () => Promise.resolve(crResponseNoMatch),
+    })
+
+    mockGotPost.mockResolvedValue({
+      statusCode: 200,
+      body: JSON.stringify({ resourceType: 'Bundle', type: 'transaction-response' }),
+    })
+
+    const bundle = {
+      resourceType: 'Bundle',
+      type: 'transaction',
+      entry: [
+        {
+          resource: {
+            resourceType: 'Patient',
+            id: 'pt-no-match',
+            identifier: [{ system: 'http://isanteplus.org/openmrs/fhir2/5-code-national', value: '00000' }],
+          },
+          request: { method: 'PUT', url: 'Patient/pt-no-match' },
+        },
+        {
+          resource: {
+            resourceType: 'AllergyIntolerance',
+            id: 'allergy-2',
+            patient: { reference: 'Patient/pt-no-match' },
+          },
+          request: { method: 'PUT', url: 'AllergyIntolerance/allergy-2' },
+        },
+      ],
+    }
+
+    const response = await request(app).post('/').send(bundle)
+    expect(response.status).toBe(200)
+
+    const sentBundle = mockGotPost.mock.calls[0][1].json
+    const allergy = sentBundle.entry[1].resource
+
+    // Reference should be unchanged
+    expect(allergy.patient.reference).toBe('Patient/pt-no-match')
+  })
+})
+
+describe('Golden Record Demographics Resolution', () => {
+  afterEach(() => {
+    mockGotGet.mockReset()
+    mockGotPost.mockReset()
+    mockGotPut.mockReset()
+    mockGotDefault.mockReset()
+  })
+
+  it('updates golden record Patient in SHR with official name from CR sources', async () => {
+    const crResponseWithMultipleNames = {
+      resourceType: 'Bundle',
+      entry: [
+        {
+          resource: {
+            resourceType: 'Patient',
+            id: 'source-1',
+            name: [{ use: 'official', family: 'DOE', given: ['JOHN'] }],
+            gender: 'male',
+            birthDate: '1985',
+            meta: { tag: [{ code: 'facility-a' }], lastUpdated: '2026-04-09T10:00:00Z' },
+            identifier: [{ system: 'http://isanteplus.org/openmrs/fhir2/3-isanteplus-id', value: 'AAA' }],
+          },
+        },
+        {
+          resource: {
+            resourceType: 'Patient',
+            id: 'source-2',
+            name: [{ use: 'official', family: 'KUNTA', given: ['SMITH'] }],
+            gender: 'male',
+            birthDate: '1985',
+            meta: { tag: [{ code: 'facility-b' }], lastUpdated: '2026-04-10T12:00:00Z' },
+            identifier: [{ system: 'http://isanteplus.org/openmrs/fhir2/3-isanteplus-id', value: 'BBB' }],
+          },
+        },
+        {
+          resource: {
+            resourceType: 'Patient',
+            id: GOLDEN_RECORD_ID,
+            meta: { tag: [{ code: GOLDEN_RECORD_CODE }] },
+          },
+        },
+      ],
+    }
+
+    mockGotGet.mockReturnValue({
+      json: () => Promise.resolve(crResponseWithMultipleNames),
+    })
+
+    mockGotPut.mockResolvedValue({ statusCode: 200, body: '{}' })
+
+    mockGotPost.mockResolvedValue({
+      statusCode: 200,
+      body: JSON.stringify({ resourceType: 'Bundle', type: 'transaction-response' }),
+    })
+
+    const bundle = {
+      resourceType: 'Bundle',
+      type: 'transaction',
+      entry: [
+        {
+          resource: {
+            resourceType: 'Patient',
+            id: 'pt-test',
+            identifier: [{ system: 'http://isanteplus.org/openmrs/fhir2/3-isanteplus-id', value: 'AAA' }],
+          },
+          request: { method: 'PUT', url: 'Patient/pt-test' },
+        },
+      ],
+    }
+
+    await request(app).post('/').send(bundle)
+
+    // Wait briefly for background golden record update
+    await new Promise(resolve => setTimeout(resolve, 100))
+
+    // Verify golden record PUT was called
+    expect(mockGotPut).toHaveBeenCalled()
+    const putCall = mockGotPut.mock.calls[0]
+    expect(putCall[0]).toContain(`Patient/${GOLDEN_RECORD_ID}`)
+
+    const goldenPatient = putCall[1].json
+
+    // Should have the official name from the MOST RECENT source (source-2, updated later)
+    expect(goldenPatient.name[0].use).toBe('official')
+    expect(goldenPatient.name[0].family).toBe('KUNTA')
+    expect(goldenPatient.name[0].given).toEqual(['SMITH'])
+
+    // Should also include the other name
+    expect(goldenPatient.name.length).toBe(2)
+
+    // Identifiers should be merged from both sources
+    expect(goldenPatient.identifier.length).toBe(2)
+    expect(goldenPatient.identifier.map((i: any) => i.value).sort()).toEqual(['AAA', 'BBB'])
   })
 })
 

--- a/src/routes/fhir.ts
+++ b/src/routes/fhir.ts
@@ -3,9 +3,9 @@ import express, { Request, Response } from 'express'
 import got from 'got'
 import URI from 'urijs'
 import config from '../lib/config'
-import { getHapiPassthrough, invalidBundle, invalidBundleMessage, emptyBundle, emptyBundleResponse } from '../lib/helpers'
+import { emptyBundle, emptyBundleResponse, getHapiPassthrough, invalidBundle, invalidBundleMessage } from '../lib/helpers'
 import logger from '../lib/winston'
-import { generateSimpleIpsBundle } from '../workflows/ipsWorkflows'
+import { generateCrossFacilityIpsBundle, generateSimpleIpsBundle } from '../workflows/ipsWorkflows'
 import { getResourceTypeEnum, isValidResourceType } from '../lib/validate'
 import { getMetadata } from '../lib/helpers'
 
@@ -30,14 +30,21 @@ const MPI_LOOKUP_TIMEOUT_MS =
  *
  * Returns the enriched patient resource, or the original if no CR match found.
  */
-async function resolvePatientMpi(patient: any): Promise<any> {
+interface MpiResolution {
+  patient: any
+  goldenRecordId: string | null
+  crSourcePatients: any[]
+}
+
+async function resolvePatientMpi(patient: any): Promise<MpiResolution> {
   const crUrl = config.get('clientRegistryUrl')
   if (!crUrl || !patient || patient.resourceType !== 'Patient') {
-    return patient
+    return { patient, goldenRecordId: null, crSourcePatients: [] }
   }
 
   const identifiers = patient.identifier ? (Array.isArray(patient.identifier) ? patient.identifier  :  [patient.identifier]): []
   let goldenRecordId: string | null = null
+  let crSourcePatients: any[] = []
 
   const options = {
     username: config.get('clientRegistryUsername') || config.get('fhirServer:username'),
@@ -68,7 +75,8 @@ async function resolvePatientMpi(patient: any): Promise<any> {
             resource.meta.tag.some((t: any) => t.code === GOLDEN_RECORD_CODE)
           ) {
             goldenRecordId = resource.id
-            break
+          } else if (resource && resource.resourceType === 'Patient') {
+            crSourcePatients.push(resource)
           }
         }
       }
@@ -99,12 +107,168 @@ async function resolvePatientMpi(patient: any): Promise<any> {
     logger.info(`MPI lookup: no golden record found for Patient/${patient.id}`)
   }
 
-  return patient
+  return { patient, goldenRecordId, crSourcePatients }
+}
+
+/**
+ * Build a golden record Patient resource from OpenCR source patients.
+ *
+ * Demographics resolution:
+ * - name: Takes the "official" name from the most recently updated source patient.
+ *         Falls back to any name if no "official" use is found.
+ *         All unique names from all sources are included on the resource.
+ * - gender, birthDate: Taken from the most recently updated source.
+ * - identifier: Merged from all sources, deduplicated by system|value.
+ * - link: "seealso" entries pointing to each source patient in the SHR.
+ */
+function buildGoldenRecordPatient(
+  goldenRecordId: string,
+  crSourcePatients: any[],
+  shrSourcePatientIds: string[],
+): any {
+  // Sort sources by lastUpdated descending — most recent first
+  const sorted = [...crSourcePatients].sort((a, b) => {
+    const ta = a.meta?.lastUpdated || ''
+    const tb = b.meta?.lastUpdated || ''
+    return tb.localeCompare(ta)
+  })
+
+  // Resolve official name: pick from the most recent source that has one
+  let officialName: any = null
+  const allNames: any[] = []
+  const seenNames = new Set<string>()
+
+  for (const source of sorted) {
+    for (const name of source.name || []) {
+      const key = `${name.use || ''}|${name.family || ''}|${(name.given || []).join(',')}`
+      if (seenNames.has(key)) continue
+      seenNames.add(key)
+
+      if (name.use === 'official' && !officialName) {
+        officialName = { ...name }
+      }
+      allNames.push(name)
+    }
+  }
+
+  // Build the name array: official name first, then others
+  const names: any[] = []
+  if (officialName) {
+    names.push(officialName)
+  }
+  for (const name of allNames) {
+    const isOfficial = officialName &&
+      name.family === officialName.family &&
+      JSON.stringify(name.given) === JSON.stringify(officialName.given) &&
+      name.use === officialName.use
+    if (!isOfficial) {
+      names.push(name)
+    }
+  }
+  // If no official name found, just use all names as-is
+  if (names.length === 0 && allNames.length > 0) {
+    names.push(...allNames)
+  }
+
+  // Gender and birthDate from most recent source
+  const mostRecent = sorted[0]
+  const gender = mostRecent?.gender
+  const birthDate = mostRecent?.birthDate
+
+  // Merge identifiers from all sources, deduplicated
+  const identifiers: any[] = []
+  const seenIds = new Set<string>()
+  for (const source of crSourcePatients) {
+    for (const ident of source.identifier || []) {
+      const key = `${ident.system || ''}|${ident.value || ''}`
+      if (!seenIds.has(key)) {
+        seenIds.add(key)
+        identifiers.push(ident)
+      }
+    }
+  }
+
+  return {
+    resourceType: 'Patient',
+    id: goldenRecordId,
+    identifier: identifiers,
+    active: true,
+    name: names,
+    gender,
+    birthDate,
+    link: shrSourcePatientIds.map(pid => ({
+      other: { reference: `Patient/${pid}` },
+      type: 'seealso',
+    })),
+  }
+}
+
+/**
+ * Update the golden record Patient resource in the SHR with demographics
+ * resolved from OpenCR source patients. Runs as a background operation
+ * so it does not block the main write path.
+ */
+async function updateGoldenRecordInShr(goldenRecordId: string, crSourcePatients: any[], shrSourcePatientIds: string[]): Promise<void> {
+  const fhirBase = config.get('fhirServer:baseURL')
+  try {
+    const goldenPatient = buildGoldenRecordPatient(goldenRecordId, crSourcePatients, shrSourcePatientIds)
+    await got.put(`${fhirBase}/Patient/${goldenRecordId}`, {
+      json: goldenPatient,
+      username: config.get('fhirServer:username'),
+      password: config.get('fhirServer:password'),
+      timeout: { request: 5000 },
+      retry: { limit: 1, methods: ['PUT' as const] },
+    })
+    logger.info(`Updated golden record Patient/${goldenRecordId} with resolved demographics`)
+  } catch (error: any) {
+    logger.warn(`Failed to update golden record Patient/${goldenRecordId}: ${error.message}`)
+  }
+}
+
+/**
+ * Rewrite Patient references in a clinical resource to use the golden record ID.
+ * Recursively traverses the resource to catch nested references (e.g., performer.actor,
+ * participant.individual) in addition to top-level fields like subject and patient.
+ */
+function rewritePatientReferences(resource: any, patientIdMap: Map<string, string>): void {
+  if (!resource || typeof resource !== 'object') return
+
+  const visited = new WeakSet<object>()
+
+  const visit = (node: any, path: string): void => {
+    if (!node || typeof node !== 'object') return
+    if (visited.has(node)) return
+    visited.add(node)
+
+    if (Array.isArray(node)) {
+      for (let i = 0; i < node.length; i++) {
+        visit(node[i], `${path}[${i}]`)
+      }
+      return
+    }
+
+    if (typeof node.reference === 'string') {
+      const ref = node.reference as string
+      const match = ref.match(/^Patient\/(.+)$/)
+      if (match && patientIdMap.has(match[1])) {
+        const goldenId = patientIdMap.get(match[1])!
+        logger.info(`Rewriting ${path}.reference: Patient/${match[1]} → Patient/${goldenId}`)
+        node.reference = `Patient/${goldenId}`
+      }
+    }
+
+    for (const key of Object.keys(node)) {
+      visit(node[key], path ? `${path}.${key}` : key)
+    }
+  }
+
+  visit(resource, 'resource')
 }
 
 /**
  * Enrich a FHIR Bundle by resolving Patient resources against the MPI.
- * Non-Patient resources are passed through unchanged.
+ * After resolving golden records, rewrites patient references in clinical
+ * resources so all data points to the golden record Patient ID.
  * Processes patients in batches of MPI_CONCURRENCY to avoid overwhelming the CR.
  */
 const MPI_CONCURRENCY = 5
@@ -118,14 +282,41 @@ async function enrichBundleWithMpi(bundle: any): Promise<any> {
 
   if (patientEntries.length === 0) return bundle
 
+  // Build a mapping of facility patient ID → golden record ID
+  const patientIdMap = new Map<string, string>()
+  // Collect CR source patients per golden record for demographics resolution
+  const goldenRecordSources = new Map<string, any[]>()
+  const goldenRecordShrPatients = new Map<string, string[]>()
+
   // Process in batches to limit concurrent CR requests
   for (let i = 0; i < patientEntries.length; i += MPI_CONCURRENCY) {
     const batch = patientEntries.slice(i, i + MPI_CONCURRENCY)
     await Promise.all(
       batch.map((entry: any) =>
         resolvePatientMpi(entry.resource)
-          .then((resolved: any) => {
-            entry.resource = resolved
+          .then((resolution: MpiResolution) => {
+            entry.resource = resolution.patient
+            if (resolution.goldenRecordId) {
+              patientIdMap.set(resolution.patient.id, resolution.goldenRecordId)
+
+              // Collect CR sources for golden record demographics — merge across resolutions
+              if (!goldenRecordSources.has(resolution.goldenRecordId)) {
+                goldenRecordSources.set(resolution.goldenRecordId, [...resolution.crSourcePatients])
+              } else {
+                const existing = goldenRecordSources.get(resolution.goldenRecordId)!
+                const existingIds = new Set(existing.map((p: any) => p.id))
+                for (const src of resolution.crSourcePatients) {
+                  if (src.id && !existingIds.has(src.id)) {
+                    existing.push(src)
+                    existingIds.add(src.id)
+                  }
+                }
+              }
+              if (!goldenRecordShrPatients.has(resolution.goldenRecordId)) {
+                goldenRecordShrPatients.set(resolution.goldenRecordId, [])
+              }
+              goldenRecordShrPatients.get(resolution.goldenRecordId)!.push(resolution.patient.id)
+            }
           })
           .catch((err: any) => {
             logger.warn(`MPI enrichment failed for Patient/${entry.resource.id}: ${err.message}`)
@@ -134,7 +325,98 @@ async function enrichBundleWithMpi(bundle: any): Promise<any> {
     )
   }
 
+  // Rewrite patient references in all non-Patient resources
+  if (patientIdMap.size > 0) {
+    logger.info(`Rewriting patient references for ${patientIdMap.size} patient(s) in bundle`)
+    for (const entry of bundle.entry) {
+      if (entry.resource && entry.resource.resourceType !== 'Patient') {
+        rewritePatientReferences(entry.resource, patientIdMap)
+      }
+    }
+
+    // Update golden record Patient resources in the SHR with resolved demographics (background)
+    for (const [grId, crSources] of goldenRecordSources.entries()) {
+      if (crSources.length > 0) {
+        const shrPids = goldenRecordShrPatients.get(grId) || []
+        updateGoldenRecordInShr(grId, crSources, shrPids).catch((err: any) => {
+          logger.warn(`Background golden record update failed for ${grId}: ${err.message}`)
+        })
+      }
+    }
+  }
+
   return bundle
+}
+
+/**
+ * Given a patient ID, find all patients in the SHR that share the same golden record.
+ * 1. Fetch Patient/<id> from HAPI FHIR
+ * 2. Check if it has a link of type "refer" to a golden record
+ * 3. If so, search for all other patients that also link to that golden record
+ * 4. Return all linked patient IDs (including the original)
+ *
+ * Falls back to [patientId] if no golden record link is found.
+ */
+async function resolveAllLinkedPatients(patientId: string): Promise<string[]> {
+  const fhirBase = config.get('fhirServer:baseURL')
+  const options = {
+    username: config.get('fhirServer:username'),
+    password: config.get('fhirServer:password'),
+  }
+
+  try {
+    // Step 1: Fetch the requested patient
+    const patient: any = await got.get(`${fhirBase}/Patient/${patientId}`, options).json()
+    if (!patient || !patient.link) return [patientId]
+
+    // Step 2: Find the golden record reference
+    let goldenRecordId: string | null = null
+    for (const link of patient.link) {
+      if (link.type === 'refer' && link.other && link.other.reference) {
+        const match = link.other.reference.match(/^Patient\/(.+)$/)
+        if (match) {
+          goldenRecordId = match[1]
+          break
+        }
+      }
+    }
+
+    if (!goldenRecordId) return [patientId]
+
+    // Step 3: Find all patients that link to this golden record (with pagination)
+    let searchUrl: string | null = `${fhirBase}/Patient?link=${encodeURIComponent(`Patient/${goldenRecordId}`)}&_elements=id&_count=200`
+    const patientIds = new Set<string>()
+
+    while (searchUrl) {
+      const bundle: any = await got.get(searchUrl, options).json()
+
+      if (bundle && bundle.entry) {
+        for (const entry of bundle.entry) {
+          if (entry.resource && entry.resource.id) {
+            patientIds.add(entry.resource.id)
+          }
+        }
+      }
+
+      const nextLink = bundle && bundle.link
+        ? bundle.link.find((link: any) => link.relation === 'next' && link.url)
+        : null
+      searchUrl = nextLink ? nextLink.url : null
+    }
+
+    // Include the golden record itself — clinical data may reference it directly
+    patientIds.add(goldenRecordId)
+
+    // Ensure the original patient is included
+    patientIds.add(patientId)
+
+    const resolvedPatientIds = Array.from(patientIds)
+    logger.info(`Golden record ${goldenRecordId}: found ${resolvedPatientIds.length} linked patients: ${resolvedPatientIds.join(', ')}`)
+    return resolvedPatientIds
+  } catch (error: any) {
+    logger.warn(`Failed to resolve linked patients for ${patientId}: ${error.message}`)
+    return [patientId]
+  }
 }
 
 router.get('/', (req: Request, res: Response) => {
@@ -188,8 +470,14 @@ router.get('/:resource/:id?/:operation?', async (req: Request, res: Response) =>
       // Handle IPS Generation.
 
       if (req.params.id && req.params.id.length > 0 && req.params.id[0] != '$') {
-        // ** If using logical id of the Patient object, create summary from objects directly connected to the patient.
-        result = await generateSimpleIpsBundle(req.params.id)
+        // Using logical id — resolve all linked patients via golden record for cross-facility IPS.
+        const allPatientIds = await resolveAllLinkedPatients(req.params.id)
+        if (allPatientIds.length > 1) {
+          logger.info(`IPS: Patient/${req.params.id} has ${allPatientIds.length} linked patients, generating cross-facility summary`)
+          result = await generateCrossFacilityIpsBundle(allPatientIds)
+        } else {
+          result = await generateSimpleIpsBundle(req.params.id)
+        }
       } else if (req.params.id == '$summary') {
         /**
          * If not using logical id, use the Client Registry to resolve patient identity:
@@ -279,7 +567,14 @@ export async function saveResource(req: any, res: any, operation?: string) {
   // Resolve Patient against MPI before saving, but do not block the save if MPI resolution fails.
   if (resourceType === 'Patient') {
     try {
-      resource = await resolvePatientMpi(resource)
+      const resolution = await resolvePatientMpi(resource)
+      resource = resolution.patient
+      // Update golden record demographics in the background
+      if (resolution.goldenRecordId && resolution.crSourcePatients.length > 0) {
+        updateGoldenRecordInShr(resolution.goldenRecordId, resolution.crSourcePatients, [resource.id]).catch((err: any) => {
+          logger.warn(`Background golden record update failed: ${err.message}`)
+        })
+      }
     } catch (error: any) {
       logger.warn(
         'Failed to resolve Patient against MPI during saveResource; continuing with original resource: ' +

--- a/src/routes/fhir.ts
+++ b/src/routes/fhir.ts
@@ -5,6 +5,7 @@ import URI from 'urijs'
 import config from '../lib/config'
 import { emptyBundle, emptyBundleResponse, getHapiPassthrough, invalidBundle, invalidBundleMessage } from '../lib/helpers'
 import logger from '../lib/winston'
+import { R4 } from '@ahryman40k/ts-fhir-types'
 import { generateCrossFacilityIpsBundle, generateSimpleIpsBundle } from '../workflows/ipsWorkflows'
 import { getResourceTypeEnum, isValidResourceType } from '../lib/validate'
 import { getMetadata } from '../lib/helpers'
@@ -31,12 +32,12 @@ const MPI_LOOKUP_TIMEOUT_MS =
  * Returns the enriched patient resource, or the original if no CR match found.
  */
 interface MpiResolution {
-  patient: any
+  patient: R4.IPatient
   goldenRecordId: string | null
-  crSourcePatients: any[]
+  crSourcePatients: R4.IPatient[]
 }
 
-async function resolvePatientMpi(patient: any): Promise<MpiResolution> {
+async function resolvePatientMpi(patient: R4.IPatient): Promise<MpiResolution> {
   const crUrl = config.get('clientRegistryUrl')
   if (!crUrl || !patient || patient.resourceType !== 'Patient') {
     return { patient, goldenRecordId: null, crSourcePatients: [] }
@@ -44,7 +45,7 @@ async function resolvePatientMpi(patient: any): Promise<MpiResolution> {
 
   const identifiers = patient.identifier ? (Array.isArray(patient.identifier) ? patient.identifier  :  [patient.identifier]): []
   let goldenRecordId: string | null = null
-  let crSourcePatients: any[] = []
+  const crSourcePatients: R4.IPatient[] = []
 
   const options = {
     username: config.get('clientRegistryUsername') || config.get('fhirServer:username'),
@@ -100,7 +101,7 @@ async function resolvePatientMpi(patient: any): Promise<MpiResolution> {
     if (!alreadyLinked) {
       patient.link.push({
         other: { reference: `Patient/${goldenRecordId}` },
-        type: 'refer',
+        type: R4.Patient_LinkTypeKind._refer,
       })
     }
   } else {
@@ -123,9 +124,9 @@ async function resolvePatientMpi(patient: any): Promise<MpiResolution> {
  */
 function buildGoldenRecordPatient(
   goldenRecordId: string,
-  crSourcePatients: any[],
+  crSourcePatients: R4.IPatient[],
   shrSourcePatientIds: string[],
-): any {
+): R4.IPatient {
   // Sort sources by lastUpdated descending — most recent first
   const sorted = [...crSourcePatients].sort((a, b) => {
     const ta = a.meta?.lastUpdated || ''
@@ -134,8 +135,8 @@ function buildGoldenRecordPatient(
   })
 
   // Resolve official name: pick from the most recent source that has one
-  let officialName: any = null
-  const allNames: any[] = []
+  let officialName: R4.IHumanName | null = null
+  const allNames: R4.IHumanName[] = []
   const seenNames = new Set<string>()
 
   for (const source of sorted) {
@@ -152,7 +153,7 @@ function buildGoldenRecordPatient(
   }
 
   // Build the name array: official name first, then others
-  const names: any[] = []
+  const names: R4.IHumanName[] = []
   if (officialName) {
     names.push(officialName)
   }
@@ -176,7 +177,7 @@ function buildGoldenRecordPatient(
   const birthDate = mostRecent?.birthDate
 
   // Merge identifiers from all sources, deduplicated
-  const identifiers: any[] = []
+  const identifiers: R4.IIdentifier[] = []
   const seenIds = new Set<string>()
   for (const source of crSourcePatients) {
     for (const ident of source.identifier || []) {
@@ -198,7 +199,7 @@ function buildGoldenRecordPatient(
     birthDate,
     link: shrSourcePatientIds.map(pid => ({
       other: { reference: `Patient/${pid}` },
-      type: 'seealso',
+      type: R4.Patient_LinkTypeKind._seealso,
     })),
   }
 }
@@ -208,7 +209,7 @@ function buildGoldenRecordPatient(
  * resolved from OpenCR source patients. Runs as a background operation
  * so it does not block the main write path.
  */
-async function updateGoldenRecordInShr(goldenRecordId: string, crSourcePatients: any[], shrSourcePatientIds: string[]): Promise<void> {
+async function updateGoldenRecordInShr(goldenRecordId: string, crSourcePatients: R4.IPatient[], shrSourcePatientIds: string[]): Promise<void> {
   const fhirBase = config.get('fhirServer:baseURL')
   try {
     const goldenPatient = buildGoldenRecordPatient(goldenRecordId, crSourcePatients, shrSourcePatientIds)
@@ -285,7 +286,7 @@ async function enrichBundleWithMpi(bundle: any): Promise<any> {
   // Build a mapping of facility patient ID → golden record ID
   const patientIdMap = new Map<string, string>()
   // Collect CR source patients per golden record for demographics resolution
-  const goldenRecordSources = new Map<string, any[]>()
+  const goldenRecordSources = new Map<string, R4.IPatient[]>()
   const goldenRecordShrPatients = new Map<string, string[]>()
 
   // Process in batches to limit concurrent CR requests
@@ -297,14 +298,15 @@ async function enrichBundleWithMpi(bundle: any): Promise<any> {
           .then((resolution: MpiResolution) => {
             entry.resource = resolution.patient
             if (resolution.goldenRecordId) {
-              patientIdMap.set(resolution.patient.id, resolution.goldenRecordId)
+              const patientId = resolution.patient.id!
+              patientIdMap.set(patientId, resolution.goldenRecordId)
 
               // Collect CR sources for golden record demographics — merge across resolutions
               if (!goldenRecordSources.has(resolution.goldenRecordId)) {
                 goldenRecordSources.set(resolution.goldenRecordId, [...resolution.crSourcePatients])
               } else {
                 const existing = goldenRecordSources.get(resolution.goldenRecordId)!
-                const existingIds = new Set(existing.map((p: any) => p.id))
+                const existingIds = new Set(existing.map((p: R4.IPatient) => p.id))
                 for (const src of resolution.crSourcePatients) {
                   if (src.id && !existingIds.has(src.id)) {
                     existing.push(src)
@@ -315,7 +317,7 @@ async function enrichBundleWithMpi(bundle: any): Promise<any> {
               if (!goldenRecordShrPatients.has(resolution.goldenRecordId)) {
                 goldenRecordShrPatients.set(resolution.goldenRecordId, [])
               }
-              goldenRecordShrPatients.get(resolution.goldenRecordId)!.push(resolution.patient.id)
+              goldenRecordShrPatients.get(resolution.goldenRecordId)!.push(patientId)
             }
           })
           .catch((err: any) => {

--- a/src/workflows/ipsWorkflows.ts
+++ b/src/workflows/ipsWorkflows.ts
@@ -232,6 +232,203 @@ export async function generateSimpleIpsBundle(patientId: string): Promise<R4.IBu
   return ipsBundle
 }
 
+/**
+ * Generate an IPS bundle that aggregates clinical data across multiple patients
+ * that share the same golden record. This enables cross-facility patient summaries.
+ *
+ * @param patientIds - Array of patient IDs linked to the same golden record
+ */
+export async function generateCrossFacilityIpsBundle(patientIds: string[]): Promise<R4.IBundle> {
+  const ipsBundle: R4.IBundle = {
+    resourceType: 'Bundle',
+  }
+
+  const ipsCompositionType: R4.ICodeableConcept = {
+    coding: [
+      {
+        system: 'http://loinc.org',
+        code: '60591-5',
+        display: 'Patient summary Document',
+      },
+    ],
+  }
+
+  try {
+    const fhirBase = config.get('fhirServer:baseURL')
+    const options = {
+      username: config.get('fhirServer:username'),
+      password: config.get('fhirServer:password'),
+    }
+
+    const ipsSections: any = {
+      Patient: [],
+      Encounter: [],
+      ServiceRequest: [],
+      DiagnosticReport: [],
+      Observation: [],
+      AllergyIntolerance: [],
+      Condition: [],
+      MedicationRequest: [],
+      MedicationStatement: [],
+      Immunization: [],
+      Procedure: [],
+    }
+
+    // Track seen resource IDs per type to deduplicate in O(1) per entry
+    const seenIds: Record<string, Set<string>> = {}
+
+    // Fetch data for each linked patient with bounded parallelism and merge into sections
+    const IPS_FETCH_CONCURRENCY = 4
+
+    const processBundleEntries = (searchBundle: R4.IBundle) => {
+      if (searchBundle && searchBundle.entry && searchBundle.entry.length > 0) {
+        for (const e of searchBundle.entry) {
+          if (e.resource && e.resource.id) {
+            const resourceKey = String(e.resource.resourceType)
+
+            if (!ipsSections[resourceKey]) {
+              ipsSections[resourceKey] = []
+            }
+            if (!seenIds[resourceKey]) {
+              seenIds[resourceKey] = new Set()
+            }
+
+            // Deduplicate by resource ID using Set for O(1) lookup
+            if (!seenIds[resourceKey].has(e.resource.id)) {
+              seenIds[resourceKey].add(e.resource.id)
+              ipsSections[resourceKey].push(e.resource)
+            }
+          }
+        }
+      }
+    }
+
+    for (let i = 0; i < patientIds.length; i += IPS_FETCH_CONCURRENCY) {
+      const batch = patientIds.slice(i, i + IPS_FETCH_CONCURRENCY)
+      const results = await Promise.all(
+        batch.map(async (pid) => {
+          try {
+            return <R4.IBundle>await got
+              .get(`${fhirBase}/Patient?_id=${encodeURIComponent(pid)}&_include=*&_revinclude=*`, options)
+              .json()
+          } catch (err: any) {
+            logger.warn(`Failed to fetch data for Patient/${pid}: ${err.message}`)
+            return null
+          }
+        }),
+      )
+      for (const result of results) {
+        if (result) processBundleEntries(result)
+      }
+    }
+
+    // Prefer the golden record Patient as the primary subject (it has "seealso" links to sources).
+    // Fall back to the first patient with demographics if no golden record is found.
+    const primaryPatient = ipsSections['Patient'].find((p: any) =>
+      p.link && p.link.some((l: any) => l.type === 'seealso')
+    ) || ipsSections['Patient'].find((p: any) => p.name && p.name.length > 0)
+      || ipsSections['Patient'][0]
+
+    if (primaryPatient) {
+      const ipsComposition: R4.IComposition = {
+        resourceType: 'Composition',
+        type: ipsCompositionType,
+        author: [{ display: 'SHR System' }],
+        subject: { reference: `Patient/${primaryPatient.id}` },
+        section: [
+          {
+            title: 'Patient Records',
+            entry: ipsSections['Patient'].map((p: R4.IPatient) => {
+              return { reference: `Patient/${p.id!}` }
+            }),
+          },
+          {
+            title: 'Allergies and Intolerances',
+            entry: ipsSections['AllergyIntolerance'].map((a: any) => {
+              return { reference: `AllergyIntolerance/${a.id}` }
+            }),
+          },
+          {
+            title: 'Problem List',
+            entry: ipsSections['Condition'].map((c: any) => {
+              return { reference: `Condition/${c.id}` }
+            }),
+          },
+          {
+            title: 'Medication Summary',
+            entry: [
+              ...ipsSections['MedicationRequest'].map((m: any) => {
+                return { reference: `MedicationRequest/${m.id}` }
+              }),
+              ...ipsSections['MedicationStatement'].map((m: any) => {
+                return { reference: `MedicationStatement/${m.id}` }
+              }),
+            ],
+          },
+          {
+            title: 'Encounters',
+            entry: ipsSections['Encounter'].map((e: R4.IEncounter) => {
+              return { reference: `Encounter/${e.id!}` }
+            }),
+          },
+          {
+            title: 'Service Requests',
+            entry: ipsSections['ServiceRequest'].map((sr: any) => {
+              return { reference: `ServiceRequest/${sr.id}` }
+            }),
+          },
+          {
+            title: 'Diagnostic Reports',
+            entry: ipsSections['DiagnosticReport'].map((dr: any) => {
+              return { reference: `DiagnosticReport/${dr.id}` }
+            }),
+          },
+          {
+            title: 'Observations',
+            entry: ipsSections['Observation'].map((o: R4.IObservation) => {
+              return { reference: `Observation/${o.id!}` }
+            }),
+          },
+          {
+            title: 'Immunizations',
+            entry: ipsSections['Immunization'].map((i: any) => {
+              return { reference: `Immunization/${i.id}` }
+            }),
+          },
+          {
+            title: 'Procedures',
+            entry: ipsSections['Procedure'].map((p: any) => {
+              return { reference: `Procedure/${p.id}` }
+            }),
+          },
+        ],
+      }
+
+      ipsBundle.type = R4.BundleTypeKind._document
+      ipsBundle.entry = []
+      ipsBundle.entry.push(ipsComposition)
+
+      // Add all resources to the bundle
+      const bundleTypes = [
+        'Patient', 'AllergyIntolerance', 'Condition', 'MedicationRequest',
+        'MedicationStatement', 'Encounter', 'ServiceRequest', 'DiagnosticReport',
+        'Observation', 'Immunization', 'Procedure',
+      ]
+      for (const rt of bundleTypes) {
+        if (ipsSections[rt] && ipsSections[rt].length > 0 && ipsBundle.entry) {
+          ipsBundle.entry = ipsBundle.entry.concat(ipsSections[rt])
+        }
+      }
+    } else {
+      logger.error(`Cannot generate cross-facility IPS: no patients found for IDs ${patientIds.join(', ')}`)
+    }
+  } catch (e) {
+    logger.error(`Cannot generate cross-facility IPS for patients ${patientIds.join(', ')}:\n${e}`)
+  }
+
+  return ipsBundle
+}
+
 export function generateUpdateBundle(
   values: R4.IDomainResource[][],
   lastUpdated?: string,


### PR DESCRIPTION
Fixes #125

## Summary

When multiple facilities register the same patient, OpenCR correctly links them to a single golden record. The SHR mediator already resolves this by adding `Patient.link` entries pointing to the golden record. However, clinical resources (AllergyIntolerance, Observation, Encounter, etc.) were passing through with their facility-local patient references unchanged. This meant that querying `$summary` or `$everything` for a facility patient only returned that facility's data clinical data from other facilities was invisible even though OpenCR had confirmed they are the same person.

This PR fixes both the write path and the read path. On the write path, `enrichBundleWithMpi()` now rewrites `subject` and `patient` references in clinical resources to the golden record Patient ID after MPI resolution. It does this via a recursive traversal of each resource to catch nested references like `performer.actor` or `participant.individual`. On the read path, the `$summary` handler now resolves all patients sharing the same golden record via `Patient.link` and aggregates their clinical data into a single cross-facility IPS document bundle.

The PR also adds golden record Patient demographics resolution. When a facility patient flows through the mediator, it fetches the source patients from OpenCR and populates the golden record in the SHR with the `official` name from the most recently updated source, merged identifiers from all sources, and `seealso` links back to each facility patient. This runs as a background operation so it does not block writes.