### PR TITLE
Add IPS Composition required fields per HL7 IPS profile

### DIFF
--- a/src/workflows/__tests__/ipsWorkflows.test.ts
+++ b/src/workflows/__tests__/ipsWorkflows.test.ts
@@ -386,3 +386,130 @@ describe('generateCrossFacilityIpsBundle', () => {
     expect(obsSection!.entry).toHaveLength(1)
   })
 })
+
+// --- IPS Composition profile conformance ---
+
+describe('IPS Composition required fields (issue #132)', () => {
+  const makeFhirSearchResponse = (entries: any[]): R4.IBundle => ({
+    resourceType: 'Bundle',
+    type: R4.BundleTypeKind._searchset,
+    entry: entries.map(r => ({ resource: r })),
+  })
+
+  const assertCompositionMetadata = (composition: R4.IComposition) => {
+    expect(composition.status).toBe(R4.CompositionStatusKind._final)
+    expect(composition.title).toBe('International Patient Summary')
+    expect(composition.date).toBeDefined()
+    // date must be a valid ISO-8601 timestamp
+    expect(Number.isNaN(Date.parse(composition.date!))).toBe(false)
+    // LOINC 60591-5 (Patient summary Document) still set on .type
+    expect(composition.type!.coding![0].code).toBe('60591-5')
+  }
+
+  const assertSectionConformance = (
+    section: NonNullable<R4.IComposition['section']>[number],
+    expectedLoincCode?: string,
+  ) => {
+    // section.code is 1..1 in the IPS profile
+    expect(section.code).toBeDefined()
+    expect(section.code!.coding).toBeDefined()
+    expect(section.code!.coding!.length).toBeGreaterThan(0)
+    if (expectedLoincCode) {
+      const loinc = section.code!.coding!.find(c => c.system === 'http://loinc.org')
+      expect(loinc).toBeDefined()
+      expect(loinc!.code).toBe(expectedLoincCode)
+    }
+
+    // section.text (narrative) is 1..1 in the IPS profile
+    expect(section.text).toBeDefined()
+    expect(section.text!.status).toBe(R4.NarrativeStatusKind._generated)
+    expect(section.text!.div).toMatch(/^<div xmlns="http:\/\/www\.w3\.org\/1999\/xhtml">/)
+
+    // emptyReason is required when there are no entries
+    if (!section.entry || section.entry.length === 0) {
+      expect(section.emptyReason).toBeDefined()
+      expect(section.emptyReason!.coding![0].system).toBe(
+        'http://terminology.hl7.org/CodeSystem/list-empty-reason',
+      )
+    } else {
+      expect(section.emptyReason).toBeUndefined()
+    }
+  }
+
+  it('generateIpsbundle: Composition has status, date, title and IPS-conformant sections', async () => {
+    const mockClient = {
+      request: jest.fn()
+        .mockResolvedValueOnce([patient1])
+        .mockResolvedValueOnce([encounter1])
+        .mockResolvedValueOnce([]),
+    }
+
+    const result = await generateIpsbundle(
+      [patient1],
+      mockClient as any,
+      '2026-01-01',
+      'http://example.org/ids',
+    )
+
+    const composition = result.entry![0] as R4.IComposition
+    assertCompositionMetadata(composition)
+
+    const sectionBy = (title: string) => composition.section!.find(s => s.title === title)!
+    assertSectionConformance(sectionBy('Patient Records'))
+    assertSectionConformance(sectionBy('Encounters'), '46240-8')
+    // Observations is empty here → must carry emptyReason
+    assertSectionConformance(sectionBy('Observations'))
+  })
+
+  it('generateCrossFacilityIpsBundle: Composition has status, date, title and IPS-conformant sections', async () => {
+    const allergy = { resourceType: 'AllergyIntolerance', id: 'al-001' }
+    const condition = { resourceType: 'Condition', id: 'cd-001' }
+    const medRequest = { resourceType: 'MedicationRequest', id: 'mr-001' }
+    const immunization = { resourceType: 'Immunization', id: 'im-001' }
+    const procedure = { resourceType: 'Procedure', id: 'pr-001' }
+
+    mockGotGet.mockReturnValueOnce({
+      json: () => Promise.resolve(makeFhirSearchResponse([
+        patient1, encounter1, observation1,
+        allergy, condition, medRequest, immunization, procedure,
+      ])),
+    })
+
+    const result = await generateCrossFacilityIpsBundle(['pt-001'])
+    const composition = result.entry![0] as R4.IComposition
+    assertCompositionMetadata(composition)
+
+    const sectionBy = (title: string) => composition.section!.find(s => s.title === title)!
+    // Required IPS sections must carry the IG-specified LOINC codes
+    assertSectionConformance(sectionBy('Allergies and Intolerances'), '48765-2')
+    assertSectionConformance(sectionBy('Problem List'), '11450-4')
+    assertSectionConformance(sectionBy('Medication Summary'), '10160-0')
+    assertSectionConformance(sectionBy('Immunizations'), '11369-6')
+    assertSectionConformance(sectionBy('Procedures'), '47519-4')
+    assertSectionConformance(sectionBy('Diagnostic Reports'), '30954-2')
+    // Non-IPS sections still get a code (project-local or LOINC) and narrative
+    assertSectionConformance(sectionBy('Patient Records'))
+    assertSectionConformance(sectionBy('Encounters'), '46240-8')
+    assertSectionConformance(sectionBy('Service Requests'))
+    assertSectionConformance(sectionBy('Observations'))
+  })
+
+  it('empty sections carry an emptyReason and narrative; populated sections do not', async () => {
+    mockGotGet.mockReturnValueOnce({
+      json: () => Promise.resolve(makeFhirSearchResponse([patient1])),
+    })
+
+    const result = await generateCrossFacilityIpsBundle(['pt-001'])
+    const composition = result.entry![0] as R4.IComposition
+
+    const emptySection = composition.section!.find(s => s.title === 'Allergies and Intolerances')!
+    expect(emptySection.entry).toHaveLength(0)
+    expect(emptySection.emptyReason).toBeDefined()
+    expect(emptySection.text!.div).toContain('No allergies and intolerances available.')
+
+    const populatedSection = composition.section!.find(s => s.title === 'Patient Records')!
+    expect(populatedSection.entry!.length).toBeGreaterThan(0)
+    expect(populatedSection.emptyReason).toBeUndefined()
+    expect(populatedSection.text!.div).toContain('Patient Records (1 entry)')
+  })
+})

--- a/src/workflows/ipsWorkflows.ts
+++ b/src/workflows/ipsWorkflows.ts
@@ -77,11 +77,32 @@ function escapeXml(input: string): string {
   }[c] as string))
 }
 
+function buildLocalSectionCode(title: string): string {
+  const slug = title
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+  return slug || 'section'
+}
+
 function buildIpsSection(title: string, entries: R4.IReference[]): R4.IComposition_Section {
   const coded = SECTION_CODES[title]
-  const code: R4.ICodeableConcept = coded
-    ? { coding: [{ system: coded.system, code: coded.code, display: coded.display }], text: title }
-    : { text: title }
+  const sectionCoding = coded
+    ? { system: coded.system, code: coded.code, display: coded.display }
+    : { system: LOCAL_SECTION_SYSTEM, code: buildLocalSectionCode(title), display: title }
+
+  if (!coded) {
+    logger.warn(
+      `Missing IPS section code mapping for title "${title}", using deterministic local code "${sectionCoding.code}"`,
+    )
+  }
+
+  const code: R4.ICodeableConcept = {
+    coding: [sectionCoding],
+    text: title,
+  }
 
   const safeTitle = escapeXml(title)
   const hasEntries = entries.length > 0

--- a/src/workflows/ipsWorkflows.ts
+++ b/src/workflows/ipsWorkflows.ts
@@ -48,11 +48,11 @@ const SECTION_CODES: Record<string, { system: string; code: string; display: str
   'Allergies and Intolerances': { system: 'http://loinc.org', code: '48765-2', display: 'Allergies and adverse reactions Document' },
   'Problem List': { system: 'http://loinc.org', code: '11450-4', display: 'Problem list - Reported' },
   'Medication Summary': { system: 'http://loinc.org', code: '10160-0', display: 'History of Medication use Narrative' },
-  'Encounters': { system: 'http://loinc.org', code: '46240-8', display: 'History of encounters Document' },
+  'Encounters': { system: 'http://loinc.org', code: '46240-8', display: 'History of Hospitalizations+Outpatient visits Narrative' },
   'Service Requests': { system: LOCAL_SECTION_SYSTEM, code: 'service-requests', display: 'Service Requests' },
-  'Diagnostic Reports': { system: 'http://loinc.org', code: '30954-2', display: 'Relevant diagnostic tests/laboratory data Narrative' },
+  'Diagnostic Reports': { system: 'http://loinc.org', code: '30954-2', display: 'Relevant diagnostic tests/laboratory data note' },
   'Observations': { system: LOCAL_SECTION_SYSTEM, code: 'observations', display: 'Observations' },
-  'Immunizations': { system: 'http://loinc.org', code: '11369-6', display: 'History of Immunization Narrative' },
+  'Immunizations': { system: 'http://loinc.org', code: '11369-6', display: 'History of Immunization note' },
   'Procedures': { system: 'http://loinc.org', code: '47519-4', display: 'History of Procedures Document' },
 }
 

--- a/src/workflows/ipsWorkflows.ts
+++ b/src/workflows/ipsWorkflows.ts
@@ -27,6 +27,101 @@ import logger from '../lib/winston'
     Advance Directives
 */
 
+const IPS_COMPOSITION_TITLE = 'International Patient Summary'
+
+const IPS_COMPOSITION_TYPE: R4.ICodeableConcept = {
+  coding: [
+    {
+      system: 'http://loinc.org',
+      code: '60591-5',
+      display: 'Patient summary Document',
+    },
+  ],
+}
+
+const LOCAL_SECTION_SYSTEM = 'http://openhie.org/sedish/CodeSystem/ips-sections'
+
+// LOINC codes are used for sections that map to the IPS IG; project-local
+// codes are used for the custom sections this mediator exposes.
+const SECTION_CODES: Record<string, { system: string; code: string; display: string }> = {
+  'Patient Records': { system: LOCAL_SECTION_SYSTEM, code: 'patient-records', display: 'Patient Records' },
+  'Allergies and Intolerances': { system: 'http://loinc.org', code: '48765-2', display: 'Allergies and adverse reactions Document' },
+  'Problem List': { system: 'http://loinc.org', code: '11450-4', display: 'Problem list - Reported' },
+  'Medication Summary': { system: 'http://loinc.org', code: '10160-0', display: 'History of Medication use Narrative' },
+  'Encounters': { system: 'http://loinc.org', code: '46240-8', display: 'History of encounters Document' },
+  'Service Requests': { system: LOCAL_SECTION_SYSTEM, code: 'service-requests', display: 'Service Requests' },
+  'Diagnostic Reports': { system: 'http://loinc.org', code: '30954-2', display: 'Relevant diagnostic tests/laboratory data Narrative' },
+  'Observations': { system: LOCAL_SECTION_SYSTEM, code: 'observations', display: 'Observations' },
+  'Immunizations': { system: 'http://loinc.org', code: '11369-6', display: 'History of Immunization Narrative' },
+  'Procedures': { system: 'http://loinc.org', code: '47519-4', display: 'History of Procedures Document' },
+}
+
+const IPS_EMPTY_REASON: R4.ICodeableConcept = {
+  coding: [
+    {
+      system: 'http://terminology.hl7.org/CodeSystem/list-empty-reason',
+      code: 'unavailable',
+      display: 'Unavailable',
+    },
+  ],
+  text: 'No data available',
+}
+
+function escapeXml(input: string): string {
+  return input.replace(/[&<>"']/g, c => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&apos;',
+  }[c] as string))
+}
+
+function buildIpsSection(title: string, entries: R4.IReference[]): R4.IComposition_Section {
+  const coded = SECTION_CODES[title]
+  const code: R4.ICodeableConcept = coded
+    ? { coding: [{ system: coded.system, code: coded.code, display: coded.display }], text: title }
+    : { text: title }
+
+  const safeTitle = escapeXml(title)
+  const hasEntries = entries.length > 0
+  const div = hasEntries
+    ? `<div xmlns="http://www.w3.org/1999/xhtml"><p>${safeTitle} (${entries.length} ${entries.length === 1 ? 'entry' : 'entries'})</p></div>`
+    : `<div xmlns="http://www.w3.org/1999/xhtml"><p>No ${safeTitle.toLowerCase()} available.</p></div>`
+
+  const section: R4.IComposition_Section = {
+    title,
+    code,
+    text: { status: R4.NarrativeStatusKind._generated, div },
+    entry: entries,
+  }
+
+  if (!hasEntries) {
+    section.emptyReason = IPS_EMPTY_REASON
+  }
+
+  return section
+}
+
+function buildIpsComposition(
+  subject: R4.IReference | null,
+  sections: R4.IComposition_Section[],
+): R4.IComposition {
+  const composition: R4.IComposition = {
+    resourceType: 'Composition',
+    status: R4.CompositionStatusKind._final,
+    type: IPS_COMPOSITION_TYPE,
+    date: new Date().toISOString(),
+    title: IPS_COMPOSITION_TITLE,
+    author: [{ display: 'SHR System' }],
+    section: sections,
+  }
+  if (subject) {
+    composition.subject = subject
+  }
+  return composition
+}
+
 export async function generateIpsbundle(
   patients: R4.IPatient[],
   shrClient: Client,
@@ -62,41 +157,20 @@ export async function generateIpsbundle(
     resourceType: 'Bundle',
   }
 
-  const ipsCompositionType: R4.ICodeableConcept = {
-    coding: [
-      {
-        system: 'http://loinc.org',
-        code: '60591-5',
-        display: 'Patient summary Document',
-      },
-    ],
-  }
-
-  const ipsComposition: R4.IComposition = {
-    resourceType: 'Composition',
-    type: ipsCompositionType,
-    author: [{ display: 'SHR System' }],
-    section: [
-      {
-        title: 'Patient Records',
-        entry: shrPatients.map((p: R4.IPatient) => {
-          return { reference: `Patient/${p.id!}` }
-        }),
-      },
-      {
-        title: 'Encounters',
-        entry: encounters.map((e: R4.IEncounter) => {
-          return { reference: `Encounter/${e.id!}` }
-        }),
-      },
-      {
-        title: 'Observations',
-        entry: observations.map((o: R4.IObservation) => {
-          return { reference: `Observation/${o.id!}` }
-        }),
-      },
-    ],
-  }
+  const ipsComposition = buildIpsComposition(null, [
+    buildIpsSection(
+      'Patient Records',
+      shrPatients.map((p: R4.IPatient) => ({ reference: `Patient/${p.id!}` })),
+    ),
+    buildIpsSection(
+      'Encounters',
+      encounters.map((e: R4.IEncounter) => ({ reference: `Encounter/${e.id!}` })),
+    ),
+    buildIpsSection(
+      'Observations',
+      observations.map((o: R4.IObservation) => ({ reference: `Observation/${o.id!}` })),
+    ),
+  ])
 
   ipsBundle.type = R4.BundleTypeKind._document
   ipsBundle.entry = []
@@ -119,16 +193,6 @@ export async function generateCrossFacilityIpsBundle(
 ): Promise<R4.IBundle> {
   const ipsBundle: R4.IBundle = {
     resourceType: 'Bundle',
-  }
-
-  const ipsCompositionType: R4.ICodeableConcept = {
-    coding: [
-      {
-        system: 'http://loinc.org',
-        code: '60591-5',
-        display: 'Patient summary Document',
-      },
-    ],
   }
 
   try {
@@ -218,79 +282,51 @@ export async function generateCrossFacilityIpsBundle(
       || ipsSections['Patient'][0]
 
     if (primaryPatient) {
-      const ipsComposition: R4.IComposition = {
-        resourceType: 'Composition',
-        type: ipsCompositionType,
-        author: [{ display: 'SHR System' }],
-        subject: { reference: `Patient/${primaryPatient.id}` },
-        section: [
-          {
-            title: 'Patient Records',
-            entry: ipsSections['Patient'].map((p: R4.IPatient) => {
-              return { reference: `Patient/${p.id!}` }
-            }),
-          },
-          {
-            title: 'Allergies and Intolerances',
-            entry: ipsSections['AllergyIntolerance'].map((a: any) => {
-              return { reference: `AllergyIntolerance/${a.id}` }
-            }),
-          },
-          {
-            title: 'Problem List',
-            entry: ipsSections['Condition'].map((c: any) => {
-              return { reference: `Condition/${c.id}` }
-            }),
-          },
-          {
-            title: 'Medication Summary',
-            entry: [
-              ...ipsSections['MedicationRequest'].map((m: any) => {
-                return { reference: `MedicationRequest/${m.id}` }
-              }),
-              ...ipsSections['MedicationStatement'].map((m: any) => {
-                return { reference: `MedicationStatement/${m.id}` }
-              }),
-            ],
-          },
-          {
-            title: 'Encounters',
-            entry: ipsSections['Encounter'].map((e: R4.IEncounter) => {
-              return { reference: `Encounter/${e.id!}` }
-            }),
-          },
-          {
-            title: 'Service Requests',
-            entry: ipsSections['ServiceRequest'].map((sr: any) => {
-              return { reference: `ServiceRequest/${sr.id}` }
-            }),
-          },
-          {
-            title: 'Diagnostic Reports',
-            entry: ipsSections['DiagnosticReport'].map((dr: any) => {
-              return { reference: `DiagnosticReport/${dr.id}` }
-            }),
-          },
-          {
-            title: 'Observations',
-            entry: ipsSections['Observation'].map((o: R4.IObservation) => {
-              return { reference: `Observation/${o.id!}` }
-            }),
-          },
-          {
-            title: 'Immunizations',
-            entry: ipsSections['Immunization'].map((i: any) => {
-              return { reference: `Immunization/${i.id}` }
-            }),
-          },
-          {
-            title: 'Procedures',
-            entry: ipsSections['Procedure'].map((p: any) => {
-              return { reference: `Procedure/${p.id}` }
-            }),
-          },
+      const ipsComposition = buildIpsComposition(
+        { reference: `Patient/${primaryPatient.id}` },
+        [
+          buildIpsSection(
+            'Patient Records',
+            ipsSections['Patient'].map((p: R4.IPatient) => ({ reference: `Patient/${p.id!}` })),
+          ),
+          buildIpsSection(
+            'Allergies and Intolerances',
+            ipsSections['AllergyIntolerance'].map((a: any) => ({ reference: `AllergyIntolerance/${a.id}` })),
+          ),
+          buildIpsSection(
+            'Problem List',
+            ipsSections['Condition'].map((c: any) => ({ reference: `Condition/${c.id}` })),
+          ),
+          buildIpsSection('Medication Summary', [
+            ...ipsSections['MedicationRequest'].map((m: any) => ({ reference: `MedicationRequest/${m.id}` })),
+            ...ipsSections['MedicationStatement'].map((m: any) => ({ reference: `MedicationStatement/${m.id}` })),
+          ]),
+          buildIpsSection(
+            'Encounters',
+            ipsSections['Encounter'].map((e: R4.IEncounter) => ({ reference: `Encounter/${e.id!}` })),
+          ),
+          buildIpsSection(
+            'Service Requests',
+            ipsSections['ServiceRequest'].map((sr: any) => ({ reference: `ServiceRequest/${sr.id}` })),
+          ),
+          buildIpsSection(
+            'Diagnostic Reports',
+            ipsSections['DiagnosticReport'].map((dr: any) => ({ reference: `DiagnosticReport/${dr.id}` })),
+          ),
+          buildIpsSection(
+            'Observations',
+            ipsSections['Observation'].map((o: R4.IObservation) => ({ reference: `Observation/${o.id!}` })),
+          ),
+          buildIpsSection(
+            'Immunizations',
+            ipsSections['Immunization'].map((i: any) => ({ reference: `Immunization/${i.id}` })),
+          ),
+          buildIpsSection(
+            'Procedures',
+            ipsSections['Procedure'].map((p: any) => ({ reference: `Procedure/${p.id}` })),
+          ),
         ],
-      }
+      )
 
       ipsBundle.type = R4.BundleTypeKind._document
       ipsBundle.entry = []


### PR DESCRIPTION
Fixes #132.

## Problem

The IPS Composition built by both `generateIpsbundle` and `generateCrossFacilityIpsBundle` was missing several fields the [IPS Composition profile](https://build.fhir.org/ig/HL7/fhir-ips/en/StructureDefinition-Composition-uv-ips.html) marks as required:

| Field | Cardinality | Previous state |
|-------|-------------|----------------|
| `Composition.status` | 1..1 | absent |
| `Composition.date` | 1..1 | absent |
| `Composition.title` | 1..1 | absent |
| `Composition.section[].code` | 1..1 | absent |
| `Composition.section[].text` | 1..1 | absent |
| `emptyReason` | conditional | absent on empty sections |

`Composition.type` (LOINC `60591-5`) was already set and is preserved.

## Changes

Introduce two helpers in `src/workflows/ipsWorkflows.ts`:

- **`buildIpsSection(title, entries)`** — attaches the section `code` (LOINC where IPS defines one, project-local code system otherwise), a generated xhtml `text` narrative, and an `emptyReason` of `unavailable` when there are no entries.
- **`buildIpsComposition(subject, sections)`** — attaches `status: "final"`, current ISO-8601 `date`, `title: "International Patient Summary"`, the IPS document `type` (LOINC `60591-5`), and `author`.

Refactor both bundle generators to build sections and the Composition through these helpers so conformance stays in sync across the two call sites.

### Section codes

| Section | System | Code |
|---------|--------|------|
| Allergies and Intolerances | LOINC | `48765-2` |
| Problem List | LOINC | `11450-4` |
| Medication Summary | LOINC | `10160-0` |
| Immunizations | LOINC | `11369-6` |
| Procedures | LOINC | `47519-4` |
| Diagnostic Reports | LOINC | `30954-2` |
| Encounters | LOINC | `46240-8` |
| Patient Records | `http://openhie.org/sedish/CodeSystem/ips-sections` | `patient-records` |
| Service Requests | *(same)* | `service-requests` |
| Observations | *(same)* | `observations` |

## Tests

Three new cases in `src/workflows/__tests__/ipsWorkflows.test.ts` lock down the conformance fields on both generators:

- `generateIpsbundle`: Composition has `status`/`date`/`title`; each section has a `code`, `text` narrative, and correct `emptyReason` presence.
- `generateCrossFacilityIpsBundle`: same, plus explicit LOINC code checks for the six IPS-standard sections.
- Empty vs. populated sections: empty sections carry `emptyReason` and a "No … available" narrative; populated sections omit `emptyReason` and have an entry-count narrative.

Full unit suite: 63 passed, 3 skipped. `tsc --noEmit` clean.