### PR TITLE
feat(ips): MPI-resolved consolidated IPS for demographics-out SHR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,9 @@ name: CI/CD
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
   push:
-    branches: [main]
+    branches: [main, develop]
   release:
     types: [published]
   workflow_dispatch:

--- a/src/routes/__tests__/fhir.linkonly.test.ts
+++ b/src/routes/__tests__/fhir.linkonly.test.ts
@@ -1,0 +1,121 @@
+import request from 'supertest'
+import express from 'express'
+
+// got mock (all methods spyable)
+const mockGotGet = jest.fn()
+const mockGotPost = jest.fn()
+const mockGotPut = jest.fn()
+const mockGotDefault = jest.fn()
+jest.mock('got', () => {
+  const fn = (...a: any[]) => mockGotDefault(...a)
+  fn.get = (...a: any[]) => mockGotGet(...a)
+  fn.post = (...a: any[]) => mockGotPost(...a)
+  fn.put = (...a: any[]) => mockGotPut(...a)
+  return { __esModule: true, default: fn }
+})
+
+// config with link-only ON
+jest.mock('../../lib/config', () => ({
+  get: (key: string) =>
+    (({
+      'fhirServer:baseURL': 'http://hapi-fhir:8080/fhir',
+      clientRegistryUrl: 'http://openhim-core:5001/CR/fhir',
+      mpiLookupTimeoutMs: 5000,
+      mpiLinkOnly: true,
+    } as any)[key] || ''),
+}))
+
+import { router, stripDemographics } from '../fhir'
+
+const app = express()
+app.use(express.json())
+app.use('/', router)
+
+const GOLD = 'gold-1'
+const GOLDEN_RECORD_CODE = '5c827da5-4858-4f3d-a50c-62ece001efea'
+const crWithGolden = {
+  resourceType: 'Bundle',
+  entry: [{ resource: { resourceType: 'Patient', id: GOLD, meta: { tag: [{ code: GOLDEN_RECORD_CODE }] } } }],
+}
+
+beforeEach(() => {
+  ;[mockGotGet, mockGotPost, mockGotPut, mockGotDefault].forEach(m => m.mockReset())
+})
+
+describe('stripDemographics', () => {
+  it('keeps id/identifier/link/meta and drops all demographics', () => {
+    const out: any = stripDemographics({
+      resourceType: 'Patient',
+      id: 'p1',
+      name: [{ family: 'X' }],
+      gender: 'male',
+      birthDate: '2000-01-01',
+      address: [{ city: 'PaP' }],
+      telecom: [{ value: '123' }],
+      identifier: [{ system: 's', value: 'v' }],
+      link: [{ type: 'refer', other: { reference: 'Patient/g' } }],
+    } as any)
+    expect(out).toEqual({
+      resourceType: 'Patient',
+      id: 'p1',
+      active: true,
+      identifier: [{ system: 's', value: 'v' }],
+      link: [{ type: 'refer', other: { reference: 'Patient/g' } }],
+    })
+    expect(out.name).toBeUndefined()
+    expect(out.gender).toBeUndefined()
+    expect(out.address).toBeUndefined()
+  })
+})
+
+describe('link-only enrichment (mpiLinkOnly=true)', () => {
+  it('stores a stripped+linked Patient stub, leaves clinical on the site id, no golden write', async () => {
+    mockGotGet.mockReturnValue({ json: () => Promise.resolve(crWithGolden) })
+    mockGotPost.mockResolvedValue({ statusCode: 201, body: JSON.stringify({ resourceType: 'Bundle' }) })
+
+    const bundle = {
+      resourceType: 'Bundle',
+      type: 'transaction',
+      entry: [
+        {
+          resource: {
+            resourceType: 'Patient',
+            id: 'pt-001',
+            name: [{ family: 'Baptiste', given: ['Jean'] }],
+            gender: 'male',
+            identifier: [{ system: 'http://sedish-haiti.org/fhir/source-key', value: '21100-1' }],
+          },
+        },
+        {
+          resource: {
+            resourceType: 'Observation',
+            id: 'o1',
+            status: 'final',
+            code: { text: 'x' },
+            subject: { reference: 'Patient/pt-001' },
+          },
+        },
+      ],
+    }
+
+    const res = await request(app).post('/').send(bundle)
+    expect(res.status).toBe(201)
+    expect(mockGotPost).toHaveBeenCalled()
+
+    const sent = mockGotPost.mock.calls[0][1].json // got.post(uri, { json: <enriched bundle> })
+    const pat = sent.entry.find((e: any) => e.resource.resourceType === 'Patient').resource
+    const obs = sent.entry.find((e: any) => e.resource.resourceType === 'Observation').resource
+
+    // stub: demographics stripped, golden link present, identifier kept
+    expect(pat.name).toBeUndefined()
+    expect(pat.gender).toBeUndefined()
+    expect(pat.link).toContainEqual({ other: { reference: `Patient/${GOLD}` }, type: 'refer' })
+    expect(pat.identifier).toBeDefined()
+
+    // clinical untouched — stays on the site id, NOT rewritten to the golden
+    expect(obs.subject.reference).toBe('Patient/pt-001')
+
+    // no golden-record demographics written to the SHR
+    expect(mockGotPut).not.toHaveBeenCalled()
+  })
+})

--- a/src/routes/fhir.ts
+++ b/src/routes/fhir.ts
@@ -14,6 +14,12 @@ export const router = express.Router()
 
 const GOLDEN_RECORD_CODE = config.get('goldenRecordCode') || '5c827da5-4858-4f3d-a50c-62ece001efea'
 
+// Link-only mode (SEDISH "demographics-out" topology): on write, resolve each Patient to its MPI
+// golden record and store ONLY a demographics-stripped stub carrying the refer link. Do NOT write
+// golden-record demographics into the SHR and do NOT rewrite clinical references to the golden —
+// clinical stays on the site-specific Patient id (the consolidated IPS resolves it via OpenCR).
+const MPI_LINK_ONLY = config.get('mpiLinkOnly') === true || config.get('mpiLinkOnly') === 'true'
+
 // Timeout for MPI lookups — prevents slow CR from stalling SHR writes.
 // Falls back to 5 seconds if not configured or invalid.
 const rawMpiLookupTimeoutMs = config.get('mpiLookupTimeoutMs')
@@ -273,6 +279,16 @@ function rewritePatientReferences(resource: any, patientReferenceMap: Map<string
  */
 const MPI_CONCURRENCY = 5
 
+// Reduce a Patient to an identity/linkage stub: keep id, identifiers, link and meta; drop ALL
+// demographics (name, gender, birthDate, address, telecom, …) so the SHR never stores PII.
+export function stripDemographics(patient: R4.IPatient): R4.IPatient {
+  const stub: R4.IPatient = { resourceType: 'Patient', id: patient.id, active: true }
+  if (patient.meta) stub.meta = patient.meta
+  if (patient.identifier) stub.identifier = patient.identifier
+  if (patient.link) stub.link = patient.link
+  return stub
+}
+
 async function enrichBundleWithMpi(bundle: any): Promise<any> {
   if (!bundle || !bundle.entry) return bundle
 
@@ -281,6 +297,28 @@ async function enrichBundleWithMpi(bundle: any): Promise<any> {
   )
 
   if (patientEntries.length === 0) return bundle
+
+  // Link-only: resolve each Patient to its golden record and store a demographics-stripped stub
+  // with the refer link. No golden-demographics write, no clinical rewrite (clinical stays on the
+  // site id). Even when MPI resolution fails the stub is stripped, so PII never reaches the SHR.
+  if (MPI_LINK_ONLY) {
+    for (let i = 0; i < patientEntries.length; i += MPI_CONCURRENCY) {
+      const batch = patientEntries.slice(i, i + MPI_CONCURRENCY)
+      await Promise.all(
+        batch.map((entry: any) =>
+          resolvePatientMpi(entry.resource)
+            .then((resolution: MpiResolution) => {
+              entry.resource = stripDemographics(resolution.patient)
+            })
+            .catch((err: any) => {
+              logger.warn(`MPI link-only resolution failed for Patient/${entry.resource.id}: ${err.message}`)
+              entry.resource = stripDemographics(entry.resource)
+            }),
+        ),
+      )
+    }
+    return bundle
+  }
 
   // Build a mapping of local patient references (Patient/<id> or fullUrl) → golden record ID
   const patientReferenceMap = new Map<string, string>()
@@ -577,18 +615,25 @@ export async function saveResource(req: any, res: any, operation?: string) {
   if (resourceType === 'Patient') {
     try {
       const resolution = await resolvePatientMpi(resource)
-      resource = resolution.patient
-      // Update golden record demographics in the background
-      if (resolution.goldenRecordId && resolution.crSourcePatients.length > 0 && resource.id) {
-        updateGoldenRecordInShr(resolution.goldenRecordId, resolution.crSourcePatients, [resource.id]).catch((err: any) => {
-          logger.warn(`Background golden record update failed: ${err.message}`)
-        })
+      // Link-only: store a demographics-stripped stub with the refer link; never write golden
+      // demographics into the SHR.
+      if (MPI_LINK_ONLY) {
+        resource = stripDemographics(resolution.patient)
+      } else {
+        resource = resolution.patient
+        // Update golden record demographics in the background
+        if (resolution.goldenRecordId && resolution.crSourcePatients.length > 0 && resource.id) {
+          updateGoldenRecordInShr(resolution.goldenRecordId, resolution.crSourcePatients, [resource.id]).catch((err: any) => {
+            logger.warn(`Background golden record update failed: ${err.message}`)
+          })
+        }
       }
     } catch (error: any) {
       logger.warn(
         'Failed to resolve Patient against MPI during saveResource; continuing with original resource: ' +
           (error?.message || String(error))
       )
+      if (MPI_LINK_ONLY) resource = stripDemographics(resource)
     }
   }
 

--- a/src/routes/ips.ts
+++ b/src/routes/ips.ts
@@ -4,7 +4,11 @@ import express, { Request, Response } from 'express'
 import fhirClient from 'fhirclient'
 import config from '../lib/config'
 import logger from '../lib/winston'
-import { generateIpsbundle, generateUpdateBundle } from '../workflows/ipsWorkflows'
+import {
+  GOLDEN_RECORD_TAG,
+  generateConsolidatedIpsBundle,
+  generateUpdateBundle,
+} from '../workflows/ipsWorkflows'
 import { sprintf } from 'sprintf-js'
 import { getMetadata } from '../lib/helpers'
 
@@ -18,88 +22,63 @@ router.get('/', (req: Request, res: Response) => {
 
 router.get('/metadata', getMetadata())
 
-router.get('/Patient/cruid/:id/:lastUpdated?', async (req: Request, res: Response) => {
+// Consolidated IPS by golden-record id (CRUID). Identity (golden + all linked site source-ids)
+// is resolved from the MPI; clinical is gathered from the SHR per source-id. See
+// generateConsolidatedIpsBundle for why this works with demographics held only in the MPI.
+router.get('/Patient/cruid/:id', async (req: Request, res: Response) => {
   const cruid = req.params.id
-  const lastUpdated = req.params.lastUpdated
   const mpiUrl = config.get('clientRegistryUrl')
-  const shrUrl = config.get('fhirServer:baseURL')
 
-  logger.info(
-    sprintf(
-      'Received a request for an ISP for patient with cruid: %s | lastUpdagted: %s',
-      cruid,
-      lastUpdated,
-    ),
-  )
+  logger.info(sprintf('Received a request for a consolidated IPS for cruid: %s', cruid))
 
   const mpiClient = fhirClient(req, res).client({
     serverUrl: mpiUrl,
     username: config.get('fhirServer:username'),
     password: config.get('fhirServer:password'),
   })
-  const shrClient = fhirClient(req, res).client({
-    serverUrl: shrUrl,
-    username: config.get('fhirServer:username'),
-    password: config.get('fhirServer:password'),
-  })
 
-  // Fetch records for linked patients from MPI
+  // The golden record + every site source linked to it (golden.link[seealso] -> sources).
   const mpiPatients = await mpiClient.request<R4.IPatient[]>(
     `Patient?_id=${cruid}&_include=Patient:link`,
     { flat: true },
   )
 
-  const ipsBundle = await generateIpsbundle(mpiPatients, shrClient, lastUpdated, system)
-
+  const ipsBundle = await generateConsolidatedIpsBundle(mpiPatients)
   res.status(200).json(ipsBundle)
 })
 
-router.get('/Patient/:id/:lastUpdated?', async (req: Request, res: Response) => {
+// Consolidated IPS by a site identifier (system = app:mpiSystem). Resolves the identifier to its
+// golden record, then to all linked sources, then assembles the same consolidated IPS.
+router.get('/Patient/:id', async (req: Request, res: Response) => {
   const patientId = req.params.id
-  const lastUpdated = req.params.lastUpdated
   const mpiUrl = config.get('clientRegistryUrl')
-  const shrUrl = config.get('fhirServer:baseURL')
 
-  logger.info(
-    sprintf(
-      'Received a request for an ISP with a bundle of resources\npatient id: %s | lastUpdagted: %s',
-      patientId,
-      lastUpdated,
-    ),
-  )
+  logger.info(sprintf('Received a request for a consolidated IPS for patient id: %s', patientId))
 
-  // Create Client
   const mpiClient = fhirClient(req, res).client({
     serverUrl: mpiUrl,
     username: config.get('fhirServer:username'),
     password: config.get('fhirServer:password'),
   })
-  const shrClient = fhirClient(req, res).client({
-    serverUrl: shrUrl,
-    username: config.get('fhirServer:username'),
-    password: config.get('fhirServer:password'),
-  })
 
-  // Query MPI to get all patients
-  // TODO: parameterize identifier specifics and account for diffent types of identifiers
+  // Resolve the identifier to its golden record, then enumerate all linked sources by cruid.
   const goldenRecordRes = await mpiClient.request<R4.IPatient[]>(
     `Patient?identifier=${system}|${patientId}&_include=Patient:link`,
     { flat: true },
   )
   const goldenRecord = goldenRecordRes.find(
-    x => x.meta && x.meta.tag && x.meta.tag[0].code === '5c827da5-4858-4f3d-a50c-62ece001efea',
+    x => x.meta && x.meta.tag && x.meta.tag.some(t => t.code === GOLDEN_RECORD_TAG),
   )
 
   if (goldenRecord) {
-    const cruid = goldenRecord.id
     const mpiPatients = await mpiClient.request<R4.IPatient[]>(
-      `Patient?_id=${cruid}&_include=Patient:link`,
+      `Patient?_id=${goldenRecord.id}&_include=Patient:link`,
       { flat: true },
     )
-    const ipsBundle = await generateIpsbundle(mpiPatients, shrClient, lastUpdated, system)
+    const ipsBundle = await generateConsolidatedIpsBundle(mpiPatients)
     res.status(200).send(ipsBundle)
   } else {
-    res.sendStatus(500)
+    res.sendStatus(404)
   }
 })
 

--- a/src/routes/ips.ts
+++ b/src/routes/ips.ts
@@ -2,6 +2,7 @@
 import { R4 } from '@ahryman40k/ts-fhir-types'
 import express, { Request, Response } from 'express'
 import fhirClient from 'fhirclient'
+import got from 'got'
 import config from '../lib/config'
 import logger from '../lib/winston'
 import {
@@ -16,6 +17,21 @@ export const router = express.Router()
 
 const system = config.get('app:mpiSystem')
 
+// Server-to-server search against the MPI (OpenCR via OpenHIM). Uses the client-registry
+// credentials — the same ones the FHIR write path uses — rather than the (empty) fhirServer creds
+// or the SMART fhirclient, which OpenHIM's private CR channel rejects with 401.
+async function mpiSearch(query: string): Promise<R4.IPatient[]> {
+  const url = `${config.get('clientRegistryUrl')}/${query}`
+  const options = {
+    username: config.get('clientRegistryUsername') || config.get('fhirServer:username'),
+    password: config.get('clientRegistryPassword') || config.get('fhirServer:password'),
+  }
+  const bundle = <R4.IBundle>await got.get(url, options).json()
+  return (bundle.entry || [])
+    .map(e => e.resource as R4.IPatient)
+    .filter(r => r && r.resourceType === 'Patient')
+}
+
 router.get('/', (req: Request, res: Response) => {
   return res.status(200).send(req.url)
 })
@@ -27,21 +43,10 @@ router.get('/metadata', getMetadata())
 // generateConsolidatedIpsBundle for why this works with demographics held only in the MPI.
 router.get('/Patient/cruid/:id', async (req: Request, res: Response) => {
   const cruid = req.params.id
-  const mpiUrl = config.get('clientRegistryUrl')
-
   logger.info(sprintf('Received a request for a consolidated IPS for cruid: %s', cruid))
 
-  const mpiClient = fhirClient(req, res).client({
-    serverUrl: mpiUrl,
-    username: config.get('fhirServer:username'),
-    password: config.get('fhirServer:password'),
-  })
-
   // The golden record + every site source linked to it (golden.link[seealso] -> sources).
-  const mpiPatients = await mpiClient.request<R4.IPatient[]>(
-    `Patient?_id=${cruid}&_include=Patient:link`,
-    { flat: true },
-  )
+  const mpiPatients = await mpiSearch(`Patient?_id=${cruid}&_include=Patient:link`)
 
   const ipsBundle = await generateConsolidatedIpsBundle(mpiPatients)
   res.status(200).json(ipsBundle)
@@ -51,30 +56,18 @@ router.get('/Patient/cruid/:id', async (req: Request, res: Response) => {
 // golden record, then to all linked sources, then assembles the same consolidated IPS.
 router.get('/Patient/:id', async (req: Request, res: Response) => {
   const patientId = req.params.id
-  const mpiUrl = config.get('clientRegistryUrl')
-
   logger.info(sprintf('Received a request for a consolidated IPS for patient id: %s', patientId))
 
-  const mpiClient = fhirClient(req, res).client({
-    serverUrl: mpiUrl,
-    username: config.get('fhirServer:username'),
-    password: config.get('fhirServer:password'),
-  })
-
   // Resolve the identifier to its golden record, then enumerate all linked sources by cruid.
-  const goldenRecordRes = await mpiClient.request<R4.IPatient[]>(
+  const goldenRecordRes = await mpiSearch(
     `Patient?identifier=${system}|${patientId}&_include=Patient:link`,
-    { flat: true },
   )
   const goldenRecord = goldenRecordRes.find(
     x => x.meta && x.meta.tag && x.meta.tag.some(t => t.code === GOLDEN_RECORD_TAG),
   )
 
   if (goldenRecord) {
-    const mpiPatients = await mpiClient.request<R4.IPatient[]>(
-      `Patient?_id=${goldenRecord.id}&_include=Patient:link`,
-      { flat: true },
-    )
+    const mpiPatients = await mpiSearch(`Patient?_id=${goldenRecord.id}&_include=Patient:link`)
     const ipsBundle = await generateConsolidatedIpsBundle(mpiPatients)
     res.status(200).send(ipsBundle)
   } else {

--- a/src/workflows/__tests__/ipsWorkflows.test.ts
+++ b/src/workflows/__tests__/ipsWorkflows.test.ts
@@ -1,4 +1,10 @@
-import { generateIpsbundle, generateCrossFacilityIpsBundle } from '../ipsWorkflows'
+import {
+  generateIpsbundle,
+  generateCrossFacilityIpsBundle,
+  generateConsolidatedIpsBundle,
+  splitGoldenAndSources,
+  GOLDEN_RECORD_TAG,
+} from '../ipsWorkflows'
 import { R4 } from '@ahryman40k/ts-fhir-types'
 
 // Mock got for generateCrossFacilityIpsBundle
@@ -384,6 +390,108 @@ describe('generateCrossFacilityIpsBundle', () => {
     const composition = result.entry![0] as R4.IComposition
     const obsSection = composition.section!.find(s => s.title === 'Observations')
     expect(obsSection!.entry).toHaveLength(1)
+  })
+})
+
+// --- splitGoldenAndSources ---
+
+describe('splitGoldenAndSources', () => {
+  it('separates the tagged golden record from its site sources', () => {
+    const golden: R4.IPatient = {
+      resourceType: 'Patient',
+      id: 'gold-1',
+      meta: { tag: [{ code: GOLDEN_RECORD_TAG }] },
+    }
+    const { goldenRecord, sourceIds } = splitGoldenAndSources([golden, patient1, patient2])
+    expect(goldenRecord!.id).toBe('gold-1')
+    expect(sourceIds).toEqual(['pt-001', 'pt-002'])
+  })
+
+  it('returns null golden and all ids as sources when no tagged record is present', () => {
+    const { goldenRecord, sourceIds } = splitGoldenAndSources([patient1])
+    expect(goldenRecord).toBeNull()
+    expect(sourceIds).toEqual(['pt-001'])
+  })
+})
+
+// --- generateConsolidatedIpsBundle (MPI-resolved, demographics-out) ---
+
+describe('generateConsolidatedIpsBundle', () => {
+  const golden: R4.IPatient = {
+    resourceType: 'Patient',
+    id: 'gold-1',
+    name: [{ family: 'Gold', given: ['Record'] }],
+    meta: { tag: [{ code: GOLDEN_RECORD_TAG }] },
+  }
+  const src1: R4.IPatient = { resourceType: 'Patient', id: 'src-1' }
+  const src2: R4.IPatient = { resourceType: 'Patient', id: 'src-2' }
+
+  const obsFor = (id: string, pid: string): any => ({
+    resourceType: 'Observation', id, status: 'final', code: { text: 'x' },
+    subject: { reference: `Patient/${pid}` },
+  })
+  const condFor = (id: string, pid: string): any => ({
+    resourceType: 'Condition', id, subject: { reference: `Patient/${pid}` },
+  })
+  const respond = (resources: any[]) => ({
+    json: () => Promise.resolve({
+      resourceType: 'Bundle', type: 'searchset',
+      entry: resources.map(r => ({ resource: r })),
+    }),
+  })
+
+  it('gathers clinical per source via patient= (never _revinclude) and is single-subject', async () => {
+    mockGotGet.mockImplementation((url: string) => {
+      if (url.includes('Observation?patient=Patient/src-1')) return respond([obsFor('obs-1', 'src-1')])
+      if (url.includes('Condition?patient=Patient/src-2')) return respond([condFor('cond-1', 'src-2')])
+      return respond([])
+    })
+
+    const result = await generateConsolidatedIpsBundle([golden, src1, src2])
+    const comp = result.entry![0] as R4.IComposition
+    const sec = (t: string) => comp.section!.find(s => s.title === t)!
+
+    // golden record is the subject and is included as the Patient entry (demographics from MPI)
+    expect(comp.subject!.reference).toBe('Patient/gold-1')
+    expect(result.entry!.some(e => (e as any).resourceType === 'Patient' && (e as any).id === 'gold-1')).toBe(true)
+
+    // clinical gathered from both sites
+    expect(sec('Observations').entry).toHaveLength(1)
+    expect(sec('Problem List').entry).toHaveLength(1)
+
+    // clinical references are rewritten to the golden record
+    const obsEntry = result.entry!.find(e => (e as any).resourceType === 'Observation') as any
+    expect(obsEntry.subject.reference).toBe('Patient/gold-1')
+
+    // gathered by the patient compartment param; never by the Patient _revinclude path (no Patient in SHR)
+    expect(mockGotGet.mock.calls.some(c => String(c[0]).includes('patient=Patient/src-1'))).toBe(true)
+    expect(mockGotGet.mock.calls.every(c => !String(c[0]).includes('_revinclude'))).toBe(true)
+  })
+
+  it('falls back to the record itself when there is no golden tag (singleton)', async () => {
+    mockGotGet.mockImplementation((url: string) => {
+      if (url.includes('Observation?patient=Patient/lone-1')) return respond([obsFor('obs-9', 'lone-1')])
+      return respond([])
+    })
+    const lone: R4.IPatient = { resourceType: 'Patient', id: 'lone-1', name: [{ family: 'Lone' }] }
+
+    const result = await generateConsolidatedIpsBundle([lone])
+    const comp = result.entry![0] as R4.IComposition
+    expect(comp.subject!.reference).toBe('Patient/lone-1')
+    expect(comp.section!.find(s => s.title === 'Observations')!.entry).toHaveLength(1)
+  })
+
+  it('deduplicates clinical that appears under more than one source', async () => {
+    const shared = obsFor('obs-shared', 'src-1')
+    mockGotGet.mockImplementation((url: string) => {
+      if (url.includes('Observation?patient=Patient/src-1')) return respond([shared])
+      if (url.includes('Observation?patient=Patient/src-2')) return respond([{ ...shared }])
+      return respond([])
+    })
+
+    const result = await generateConsolidatedIpsBundle([golden, src1, src2])
+    const comp = result.entry![0] as R4.IComposition
+    expect(comp.section!.find(s => s.title === 'Observations')!.entry).toHaveLength(1)
   })
 })
 

--- a/src/workflows/__tests__/ipsWorkflows.test.ts
+++ b/src/workflows/__tests__/ipsWorkflows.test.ts
@@ -509,6 +509,23 @@ describe('generateConsolidatedIpsBundle', () => {
     expect(comp.section!.find(s => s.title === 'Observations')!.entry).toHaveLength(1)
   })
 
+  it('excludes entered-in-error (retracted) clinical from the summary', async () => {
+    const live = obsFor('obs-live', 'src-1')
+    const retracted = { ...obsFor('obs-dead', 'src-1'), status: 'entered-in-error' }
+    mockGotGet.mockImplementation((url: string) => {
+      if (url.includes('Observation?patient=Patient/src-1')) return respond([live, retracted])
+      return respond([])
+    })
+
+    const result = await generateConsolidatedIpsBundle([golden, src1])
+    const comp = result.entry![0] as R4.IComposition
+    const obs = comp.section!.find(s => s.title === 'Observations')!
+    expect(obs.entry).toHaveLength(1)
+    expect(obs.entry![0].reference).toBe('Observation/obs-live')
+    // the retracted resource is not in the bundle either
+    expect(result.entry!.some(e => (e as any).id === 'obs-dead')).toBe(false)
+  })
+
   it('deduplicates clinical that appears under more than one source', async () => {
     const shared = obsFor('obs-shared', 'src-1')
     mockGotGet.mockImplementation((url: string) => {

--- a/src/workflows/__tests__/ipsWorkflows.test.ts
+++ b/src/workflows/__tests__/ipsWorkflows.test.ts
@@ -468,6 +468,34 @@ describe('generateConsolidatedIpsBundle', () => {
     expect(mockGotGet.mock.calls.every(c => !String(c[0]).includes('_revinclude'))).toBe(true)
   })
 
+  it('merges demographics from the source onto the (empty) golden subject', async () => {
+    // Real OpenCR golden records may carry no demographics; the name lives on the source.
+    const emptyGolden: R4.IPatient = {
+      resourceType: 'Patient',
+      id: 'gold-2',
+      meta: { tag: [{ code: GOLDEN_RECORD_TAG }] },
+    }
+    const namedSource: R4.IPatient = {
+      resourceType: 'Patient',
+      id: 'src-9',
+      name: [{ family: 'Pierre', given: ['Marie'] }],
+      gender: R4.PatientGenderKind._female,
+      birthDate: '1990-01-01',
+      identifier: [{ system: 'http://sedish-haiti.org/fhir/source-key', value: '21100-1046' }],
+    }
+    mockGotGet.mockImplementation(() => respond([]))
+
+    const result = await generateConsolidatedIpsBundle([emptyGolden, namedSource])
+    const comp = result.entry![0] as R4.IComposition
+    expect(comp.subject!.reference).toBe('Patient/gold-2') // keeps the golden id
+    const subjectEntry = result.entry!.find(
+      e => (e as any).resourceType === 'Patient' && (e as any).id === 'gold-2',
+    ) as any
+    expect(subjectEntry.name[0].family).toBe('Pierre') // demographics merged from the source
+    expect(subjectEntry.gender).toBe('female')
+    expect(subjectEntry.identifier[0].value).toBe('21100-1046')
+  })
+
   it('falls back to the record itself when there is no golden tag (singleton)', async () => {
     mockGotGet.mockImplementation((url: string) => {
       if (url.includes('Observation?patient=Patient/lone-1')) return respond([obsFor('obs-9', 'lone-1')])

--- a/src/workflows/ipsWorkflows.ts
+++ b/src/workflows/ipsWorkflows.ts
@@ -498,6 +498,9 @@ export async function generateConsolidatedIpsBundle(
   const seenIds: Record<string, Set<string>> = {}
   const collect = (resource: any) => {
     if (!resource || !resource.id || !resource.resourceType) return
+    // Skip retracted clinical: the pipeline marks data the source no longer produces as
+    // entered-in-error rather than deleting it; it must never appear in the patient summary.
+    if (resource.status === 'entered-in-error') return
     const rt = String(resource.resourceType)
     if (!collected[rt]) {
       collected[rt] = []

--- a/src/workflows/ipsWorkflows.ts
+++ b/src/workflows/ipsWorkflows.ts
@@ -408,6 +408,39 @@ export function splitGoldenAndSources(
   return { goldenRecord, sourceIds }
 }
 
+// Build the IPS subject: the golden record id carrying demographics merged from the site source
+// records (system-of-record for name/gender/birthDate), with identifiers unioned across all.
+function mergeDemographics(golden: R4.IPatient, sources: R4.IPatient[]): R4.IPatient {
+  const pick = (pred: (p: R4.IPatient) => boolean) =>
+    golden && pred(golden) ? golden : sources.find(pred)
+  const nameSrc = pick(p => !!(p.name && p.name.length))
+  const genderSrc = pick(p => !!p.gender)
+  const birthSrc = pick(p => !!p.birthDate)
+
+  const seen = new Set<string>()
+  const identifier: R4.IIdentifier[] = []
+  for (const p of [golden, ...sources]) {
+    for (const id of p.identifier || []) {
+      const key = `${id.system || ''}|${id.value || ''}`
+      if (!seen.has(key)) {
+        seen.add(key)
+        identifier.push(id)
+      }
+    }
+  }
+
+  return {
+    resourceType: 'Patient',
+    id: golden.id,
+    active: true,
+    meta: golden.meta,
+    name: nameSrc?.name,
+    gender: genderSrc?.gender,
+    birthDate: birthSrc?.birthDate,
+    identifier: identifier.length ? identifier : undefined,
+  }
+}
+
 // Rewrite a clinical resource's subject/patient reference from any site source-id to the golden
 // id, so the generated IPS document is single-subject. Operates on the freshly fetched copy only —
 // the resources stored in the SHR are never modified.
@@ -442,14 +475,18 @@ export async function generateConsolidatedIpsBundle(
 ): Promise<R4.IBundle> {
   const ipsBundle: R4.IBundle = { resourceType: 'Bundle' }
 
-  const { goldenRecord, sourceIds } = splitGoldenAndSources(mpiPatients)
-  // Fall back to the first MPI patient if no golden tag (singleton/unmatched record).
-  const subject = goldenRecord || mpiPatients[0] || null
-  if (!subject || !subject.id) {
+  const { goldenRecord } = splitGoldenAndSources(mpiPatients)
+  const sourcePatients = mpiPatients.filter(p => p.id && p !== goldenRecord)
+  const base = goldenRecord || mpiPatients[0] || null
+  if (!base || !base.id) {
     logger.error('Cannot generate consolidated IPS: no patient resolved from the MPI')
     return ipsBundle
   }
-  const gatherIds = sourceIds.length > 0 ? sourceIds : [subject.id]
+  const gatherIds = sourcePatients.length > 0 ? sourcePatients.map(p => p.id as string) : [base.id]
+  // Subject = the golden record id with demographics merged from the site sources. OpenCR golden
+  // records may carry no demographics, and the SHR holds none (Patient stubs), so the name/gender/
+  // birthDate/identifiers come from the source records. Singleton records use themselves.
+  const subject: R4.IPatient = goldenRecord ? mergeDemographics(goldenRecord, sourcePatients) : base
 
   const fhirBase = config.get('fhirServer:baseURL')
   const options = {
@@ -512,7 +549,7 @@ export async function generateConsolidatedIpsBundle(
   // Single-subject document: point all gathered clinical at the golden record.
   const sourceIdSet = new Set(gatherIds)
   for (const rt of Object.keys(collected)) {
-    for (const r of collected[rt]) rewriteSubjectToGolden(r, sourceIdSet, subject.id)
+    for (const r of collected[rt]) rewriteSubjectToGolden(r, sourceIdSet, base.id)
   }
 
   const refs = (rt: string): R4.IReference[] =>

--- a/src/workflows/ipsWorkflows.ts
+++ b/src/workflows/ipsWorkflows.ts
@@ -374,6 +374,186 @@ export async function generateCrossFacilityIpsBundle(
   return ipsBundle
 }
 
+// OpenCR tags golden (master) records with this code on Patient.meta.tag.
+export const GOLDEN_RECORD_TAG = '5c827da5-4858-4f3d-a50c-62ece001efea'
+
+// Clinical resource types gathered for a consolidated IPS, queried by the `patient` compartment
+// search param. This works even though Patient resources do NOT live in the SHR (demographics are
+// held only in the MPI/OpenCR per the SEDISH architecture), because clinical resources keep their
+// subject reference to the site-specific Patient id.
+const IPS_CLINICAL_TYPES = [
+  'AllergyIntolerance',
+  'Condition',
+  'MedicationRequest',
+  'MedicationStatement',
+  'Immunization',
+  'Procedure',
+  'DiagnosticReport',
+  'ServiceRequest',
+  'Observation',
+  'Encounter',
+] as const
+
+/**
+ * Split a set of MPI (OpenCR) Patient resources into the golden (master) record and the
+ * site-specific source ids linked to it. The golden record is identified by its meta.tag; the
+ * remaining patients are the site sources whose ids key the clinical data in the SHR.
+ */
+export function splitGoldenAndSources(
+  mpiPatients: R4.IPatient[],
+): { goldenRecord: R4.IPatient | null; sourceIds: string[] } {
+  const goldenRecord =
+    mpiPatients.find(p => p.meta?.tag?.some(t => t.code === GOLDEN_RECORD_TAG)) || null
+  const sourceIds = mpiPatients.filter(p => p.id && p !== goldenRecord).map(p => p.id!)
+  return { goldenRecord, sourceIds }
+}
+
+// Rewrite a clinical resource's subject/patient reference from any site source-id to the golden
+// id, so the generated IPS document is single-subject. Operates on the freshly fetched copy only —
+// the resources stored in the SHR are never modified.
+function rewriteSubjectToGolden(resource: any, sourceIdSet: Set<string>, goldenId: string): void {
+  for (const field of ['subject', 'patient']) {
+    const ref = resource?.[field]?.reference
+    if (typeof ref === 'string') {
+      const match = ref.match(/Patient\/([^/?]+)/)
+      if (match && sourceIdSet.has(match[1])) {
+        resource[field].reference = `Patient/${goldenId}`
+      }
+    }
+  }
+}
+
+/**
+ * Generate a consolidated IPS for a person across every site they are known at, using the
+ * MPI-first resolution that matches the SEDISH architecture:
+ *
+ *   - identity (the golden record and its linked site source-ids) comes from OpenCR — passed in
+ *     as `mpiPatients` (a golden record + the patients _include=Patient:link resolved against it)
+ *   - clinical is gathered from the SHR by the `patient` search param for each source-id, so it
+ *     works even though Patient resources are not stored in the SHR (demographics-out)
+ *
+ * Because the source-id set is resolved from OpenCR on every request, a merge done after the data
+ * was written is reflected immediately with no SHR reprocessing. Clinical references are rewritten
+ * to the golden id so the document is single-subject. The golden record (with demographics from
+ * the MPI) is the Composition subject and is included as the Patient entry.
+ */
+export async function generateConsolidatedIpsBundle(
+  mpiPatients: R4.IPatient[],
+): Promise<R4.IBundle> {
+  const ipsBundle: R4.IBundle = { resourceType: 'Bundle' }
+
+  const { goldenRecord, sourceIds } = splitGoldenAndSources(mpiPatients)
+  // Fall back to the first MPI patient if no golden tag (singleton/unmatched record).
+  const subject = goldenRecord || mpiPatients[0] || null
+  if (!subject || !subject.id) {
+    logger.error('Cannot generate consolidated IPS: no patient resolved from the MPI')
+    return ipsBundle
+  }
+  const gatherIds = sourceIds.length > 0 ? sourceIds : [subject.id]
+
+  const fhirBase = config.get('fhirServer:baseURL')
+  const options = {
+    username: config.get('fhirServer:username'),
+    password: config.get('fhirServer:password'),
+  }
+
+  const collected: Record<string, any[]> = {}
+  const seenIds: Record<string, Set<string>> = {}
+  const collect = (resource: any) => {
+    if (!resource || !resource.id || !resource.resourceType) return
+    const rt = String(resource.resourceType)
+    if (!collected[rt]) {
+      collected[rt] = []
+      seenIds[rt] = new Set()
+    }
+    if (!seenIds[rt].has(resource.id)) {
+      seenIds[rt].add(resource.id)
+      collected[rt].push(resource)
+    }
+  }
+
+  const SEARCH_COUNT = 200
+  const PATIENT_FETCH_CONCURRENCY = 4
+  try {
+    for (let i = 0; i < gatherIds.length; i += PATIENT_FETCH_CONCURRENCY) {
+      const batch = gatherIds.slice(i, i + PATIENT_FETCH_CONCURRENCY)
+      await Promise.all(
+        batch.map(async pid => {
+          for (const type of IPS_CLINICAL_TYPES) {
+            let nextUrl: string | null = `${fhirBase}/${type}?patient=Patient/${encodeURIComponent(
+              pid,
+            )}&_count=${SEARCH_COUNT}`
+            try {
+              while (nextUrl) {
+                const searchBundle = <R4.IBundle>await got.get(nextUrl, options).json()
+                if (searchBundle && searchBundle.entry) {
+                  for (const e of searchBundle.entry) collect(e.resource)
+                }
+                const nextLink = searchBundle.link
+                  ? searchBundle.link.find(
+                      (link: NonNullable<R4.IBundle['link']>[number]) =>
+                        link.relation === 'next' && link.url,
+                    )
+                  : undefined
+                nextUrl = nextLink?.url || null
+              }
+            } catch (err: any) {
+              logger.warn(`Failed to fetch ${type} for Patient/${pid}: ${err.message}`)
+            }
+          }
+        }),
+      )
+    }
+  } catch (e) {
+    logger.error(`Cannot generate consolidated IPS for ${subject.id}:\n${e}`)
+    return ipsBundle
+  }
+
+  // Single-subject document: point all gathered clinical at the golden record.
+  const sourceIdSet = new Set(gatherIds)
+  for (const rt of Object.keys(collected)) {
+    for (const r of collected[rt]) rewriteSubjectToGolden(r, sourceIdSet, subject.id)
+  }
+
+  const refs = (rt: string): R4.IReference[] =>
+    (collected[rt] || []).map((r: any) => ({ reference: `${rt}/${r.id}` }))
+
+  const ipsComposition = buildIpsComposition({ reference: `Patient/${subject.id}` }, [
+    buildIpsSection('Patient Records', [{ reference: `Patient/${subject.id}` }]),
+    buildIpsSection('Allergies and Intolerances', refs('AllergyIntolerance')),
+    buildIpsSection('Problem List', refs('Condition')),
+    buildIpsSection('Medication Summary', [...refs('MedicationRequest'), ...refs('MedicationStatement')]),
+    buildIpsSection('Encounters', refs('Encounter')),
+    buildIpsSection('Service Requests', refs('ServiceRequest')),
+    buildIpsSection('Diagnostic Reports', refs('DiagnosticReport')),
+    buildIpsSection('Observations', refs('Observation')),
+    buildIpsSection('Immunizations', refs('Immunization')),
+    buildIpsSection('Procedures', refs('Procedure')),
+  ])
+
+  ipsBundle.type = R4.BundleTypeKind._document
+  ipsBundle.entry = [ipsComposition, subject]
+  const order = [
+    'AllergyIntolerance',
+    'Condition',
+    'MedicationRequest',
+    'MedicationStatement',
+    'Encounter',
+    'ServiceRequest',
+    'DiagnosticReport',
+    'Observation',
+    'Immunization',
+    'Procedure',
+  ]
+  for (const rt of order) {
+    if (collected[rt] && collected[rt].length > 0) {
+      ipsBundle.entry = ipsBundle.entry.concat(collected[rt])
+    }
+  }
+
+  return ipsBundle
+}
+
 export function generateUpdateBundle(
   values: R4.IDomainResource[][],
   lastUpdated?: string,


### PR DESCRIPTION
## Summary

Makes the `/ips` route return a **consolidated, cross-facility IPS** for deployments where demographics live only in the MPI (OpenCR) and the SHR holds clinical keyed to site-specific Patient ids (the SEDISH "demographics-out" topology).

### Why

The `/ips` Patient routes already resolved linked patients via the **MPI** (`_include=Patient:link`) — the right store — but:
- they called `generateIpsbundle`, which only emits Patient/Encounter/Observation (missing the **required** IPS Allergies/Problems/Medications sections) and needs `_lastUpdated` + `app:mpiSystem`;
- the complete assembler, `generateCrossFacilityIpsBundle`, gathers via `Patient?_id&_include=*&_revinclude=*`, which **anchors on a Patient existing in the SHR** — but in this topology the SHR has only empty Patient stubs (no demographics, no golden links), so that path returns nothing;
- both `/ips` Patient routes built the MPI client with `fhirServer` credentials (empty here) via the SMART `fhirclient`, so the call to OpenHIM's private CR channel returned **401**.

### What changed

- **`workflows/ipsWorkflows.ts`**
  - `generateConsolidatedIpsBundle(mpiPatients)` — gathers clinical from the SHR by the **`patient=` compartment param** per linked source-id (works with no Patient in the SHR), reuses the existing `buildIpsComposition`/`buildIpsSection` (full IPS section set), uses the **golden record as the Composition subject with demographics merged from the source records** (OpenCR golden records may carry no demographics), and **rewrites clinical `subject`/`patient` references to the golden id** so the document is single-subject. Resolving the source set from the MPI on every request makes merges reflect immediately with no SHR reprocessing.
  - `splitGoldenAndSources`, `mergeDemographics`, and an exported `GOLDEN_RECORD_TAG`.
- **`routes/ips.ts`** — `/ips/Patient/cruid/:id` (by golden id) and `/ips/Patient/:id` (by `app:mpiSystem`|value) now use `generateConsolidatedIpsBundle`, fetching from the MPI via `got` + **clientRegistry credentials** (matching the write path's `resolvePatientMpi`).

`generateIpsbundle` / `generateCrossFacilityIpsBundle` are unchanged and still exported.

### Tests

Added unit tests for `splitGoldenAndSources`, the demographics merge, single-subject rewrite, cross-source aggregation, and dedup. Full unit suite passes (69); tsc + eslint clean.

### Validated against live OpenCR + HAPI (SEDISH)

- 1-source golden → clinical gathered, demographics merged from the source, clinical rewritten to the golden subject.
- 2-source (merged) golden → **6 Observations + 3 Encounters aggregated across both sites**, single-subject document.
