### PR TITLE
Create the golden record stub atomically in link-only mode (no HAPI placeholder)

### DIFF
--- a/src/routes/__tests__/fhir.linkonly.test.ts
+++ b/src/routes/__tests__/fhir.linkonly.test.ts
@@ -115,7 +115,40 @@ describe('link-only enrichment (mpiLinkOnly=true)', () => {
     // clinical untouched — stays on the site id, NOT rewritten to the golden
     expect(obs.subject.reference).toBe('Patient/pt-001')
 
-    // no golden-record demographics written to the SHR
+    // golden record created as a demographics-free stub IN the same transaction (atomic — no bare
+    // HAPI placeholder, no background-PUT race)
+    const golden = sent.entry.find((e: any) => e.resource.resourceType === 'Patient' && e.resource.id === GOLD)
+    expect(golden).toBeDefined()
+    expect(golden.request).toEqual({ method: 'PUT', url: `Patient/${GOLD}` })
+    expect(golden.resource.meta.tag).toContainEqual({ code: GOLDEN_RECORD_CODE })
+    expect(golden.resource.name).toBeUndefined()
+    expect(golden.resource.gender).toBeUndefined()
+
+    // the stub is injected into the bundle, not written via a separate PUT
     expect(mockGotPut).not.toHaveBeenCalled()
+  })
+
+  it('saveResource: creates the golden stub (awaited) when saving a single Patient', async () => {
+    mockGotGet.mockReturnValue({ json: () => Promise.resolve(crWithGolden) })
+    mockGotPut.mockResolvedValue({ statusCode: 200, body: '{}' })
+    mockGotDefault.mockResolvedValue({
+      statusCode: 201,
+      body: JSON.stringify({ resourceType: 'Patient', id: 'pt-9' }),
+    })
+
+    await request(app).post('/Patient').send({
+      resourceType: 'Patient',
+      id: 'pt-9',
+      name: [{ family: 'Pierre' }],
+      gender: 'female',
+      identifier: [{ system: 'http://sedish-haiti.org/fhir/source-key', value: '21100-9' }],
+    })
+
+    // golden created as a demographics-free stub, awaited (not fire-and-forget)
+    expect(mockGotPut).toHaveBeenCalled()
+    const [url, opts] = mockGotPut.mock.calls[0]
+    expect(url).toBe(`http://hapi-fhir:8080/fhir/Patient/${GOLD}`)
+    expect(opts.json.meta.tag).toContainEqual({ code: GOLDEN_RECORD_CODE })
+    expect(opts.json.name).toBeUndefined()
   })
 })

--- a/src/routes/fhir.ts
+++ b/src/routes/fhir.ts
@@ -289,6 +289,36 @@ export function stripDemographics(patient: R4.IPatient): R4.IPatient {
   return stub
 }
 
+// A demographics-free golden-record stub. In link-only mode the source stubs carry a refer link to
+// Patient/<golden>; we create that golden ourselves as a controlled, tagged stub instead of relying
+// on HAPI to auto-create a bare placeholder. Keeps the SHR demographics-out (no PII on the golden).
+export function buildGoldenStub(goldenRecordId: string): R4.IPatient {
+  return {
+    resourceType: 'Patient',
+    id: goldenRecordId,
+    active: true,
+    meta: { tag: [{ code: GOLDEN_RECORD_CODE }] },
+  }
+}
+
+// Ensure the golden record exists in the SHR as a demographics-free stub (single-resource path).
+// Awaited (not fire-and-forget) so the refer target exists before the source stub is saved; failure
+// is logged but non-fatal (HAPI's placeholder behaviour still backstops the reference).
+async function ensureGoldenStub(goldenRecordId: string): Promise<void> {
+  const fhirBase = config.get('fhirServer:baseURL')
+  try {
+    await got.put(`${fhirBase}/Patient/${goldenRecordId}`, {
+      json: buildGoldenStub(goldenRecordId),
+      username: config.get('fhirServer:username'),
+      password: config.get('fhirServer:password'),
+      timeout: { request: 5000 },
+      retry: { limit: 1, methods: ['PUT' as const] },
+    })
+  } catch (error: any) {
+    logger.warn(`Failed to create golden record stub Patient/${goldenRecordId}: ${error.message}`)
+  }
+}
+
 async function enrichBundleWithMpi(bundle: any): Promise<any> {
   if (!bundle || !bundle.entry) return bundle
 
@@ -302,6 +332,7 @@ async function enrichBundleWithMpi(bundle: any): Promise<any> {
   // with the refer link. No golden-demographics write, no clinical rewrite (clinical stays on the
   // site id). Even when MPI resolution fails the stub is stripped, so PII never reaches the SHR.
   if (MPI_LINK_ONLY) {
+    const goldenIds = new Set<string>()
     for (let i = 0; i < patientEntries.length; i += MPI_CONCURRENCY) {
       const batch = patientEntries.slice(i, i + MPI_CONCURRENCY)
       await Promise.all(
@@ -309,6 +340,7 @@ async function enrichBundleWithMpi(bundle: any): Promise<any> {
           resolvePatientMpi(entry.resource)
             .then((resolution: MpiResolution) => {
               entry.resource = stripDemographics(resolution.patient)
+              if (resolution.goldenRecordId) goldenIds.add(resolution.goldenRecordId)
             })
             .catch((err: any) => {
               logger.warn(`MPI link-only resolution failed for Patient/${entry.resource.id}: ${err.message}`)
@@ -316,6 +348,21 @@ async function enrichBundleWithMpi(bundle: any): Promise<any> {
             }),
         ),
       )
+    }
+    // Create each golden record as a demographics-free stub in the SAME transaction, so the refer
+    // target exists atomically — no reliance on HAPI auto-placeholders, no background-PUT race.
+    const presentPatientIds = new Set(
+      bundle.entry
+        .filter((e: any) => e.resource && e.resource.resourceType === 'Patient' && e.resource.id)
+        .map((e: any) => e.resource.id),
+    )
+    for (const gid of goldenIds) {
+      if (!presentPatientIds.has(gid)) {
+        bundle.entry.push({
+          resource: buildGoldenStub(gid),
+          request: { method: 'PUT', url: `Patient/${gid}` },
+        })
+      }
     }
     return bundle
   }
@@ -619,6 +666,10 @@ export async function saveResource(req: any, res: any, operation?: string) {
       // demographics into the SHR.
       if (MPI_LINK_ONLY) {
         resource = stripDemographics(resolution.patient)
+        // Create the golden as a demographics-free stub first (awaited) so the refer target exists.
+        if (resolution.goldenRecordId && resolution.goldenRecordId !== resource.id) {
+          await ensureGoldenStub(resolution.goldenRecordId)
+        }
       } else {
         resource = resolution.patient
         // Update golden record demographics in the background


### PR DESCRIPTION
## Problem
In `mpiLinkOnly` mode the SHR stores each source Patient as a demographics-free stub carrying a `refer` link to `Patient/<golden>`. HAPI then **auto-creates a bare placeholder** for that golden id (`auto_create_placeholder_reference_targets`). Those empty placeholders accumulate and muddy the registry, and the behaviour silently depends on a HAPI setting.

(Note: this is the *link-only* cause. The non-link-only path has a separate issue — the fire-and-forget `updateGoldenRecordInShr` PUT — which this PR does not touch.)

## Change
Create the golden ourselves, as a **demographics-free, tagged stub**, in the same write:
- **`enrichBundleWithMpi`** (bundle path): collect the resolved golden ids and inject one `PUT Patient/<golden>` entry per golden into the **same transaction bundle** (deduped; skipped if the golden is already a Patient entry). Atomic with the clinical/stub writes — no placeholder, no race.
- **`saveResource`** (single-resource path): `ensureGoldenStub()` — an **awaited** (not fire-and-forget) PUT of the stub before the source stub is saved.

The stub is `{ resourceType: 'Patient', id, active: true, meta.tag: [{ code: GOLDEN_RECORD_CODE }] }` — no demographics, so the SHR stays demographics-out.

## Tests
`fhir.linkonly.test.ts` extended: asserts the injected golden bundle entry (tagged, no PII, `PUT` request) and the `saveResource` golden-stub PUT. Full suite green (`tsc --noEmit` clean; 73 passed / 3 skipped).