### PR TITLE
feat(ips): add fpnid retrieval path to consolidated IPS

### DIFF
--- a/config/config_docker.json
+++ b/config/config_docker.json
@@ -1,7 +1,8 @@
 {
   "app": {
     "port": 3000,
-    "mllpPort": 3001
+    "mllpPort": 3001,
+    "fpnidSystem": "http://isanteplus.org/openmrs/fhir2/6-biometrics-national-reference-code"
   },
   "mediator": {
     "api": {

--- a/src/routes/__tests__/ips.test.ts
+++ b/src/routes/__tests__/ips.test.ts
@@ -1,17 +1,89 @@
+const GOLDEN_TAG = '5c827da5-4858-4f3d-a50c-62ece001efea'
+const FPNID_SYSTEM = 'http://isanteplus.org/openmrs/fhir2/6-biometrics-national-reference-code'
+
+const golden = {
+  resourceType: 'Patient',
+  id: 'golden-1',
+  meta: { tag: [{ code: GOLDEN_TAG }] },
+  link: [{ type: 'seealso', other: { reference: 'Patient/src-1' } }],
+}
+const source = {
+  resourceType: 'Patient',
+  id: 'src-1',
+  identifier: [{ system: FPNID_SYSTEM, value: 'HT-0001' }],
+}
+
+// mpiSearch calls got.get(url, opts).json(); capture the url so we can assert the query system.
+const mockGotGet = jest.fn()
+jest.mock('got', () => ({
+  __esModule: true,
+  default: { get: (...args: unknown[]) => mockGotGet(...args) },
+}))
+
+// Isolate the route from the (heavy) IPS assembler while keeping the real GOLDEN_RECORD_TAG.
+jest.mock('../../workflows/ipsWorkflows', () => {
+  const actual = jest.requireActual('../../workflows/ipsWorkflows')
+  return {
+    ...actual,
+    generateConsolidatedIpsBundle: jest.fn(async () => ({
+      resourceType: 'Bundle',
+      type: 'document',
+      id: 'ips-1',
+    })),
+  }
+})
+
 import request from 'supertest'
 import express from 'express'
 import { router } from '../ips'
+import { generateConsolidatedIpsBundle } from '../../workflows/ipsWorkflows'
 
 const app = express()
 app.use('/', router)
 
 describe('IPS Routes', () => {
-
   it.skip('should return 200 OK for GET /metadata', async () => {
-    
-    
     const response = await request(app).get('/metadata')
-
     expect(response.status).toBe(200)
+  })
+})
+
+describe('IPS fpnid retrieval', () => {
+  beforeEach(() => {
+    mockGotGet.mockReset()
+    ;(generateConsolidatedIpsBundle as jest.Mock).mockClear()
+  })
+
+  it('resolves an fpnid to the golden record and returns a consolidated IPS (200)', async () => {
+    mockGotGet.mockImplementation((url: string) => ({
+      json: async () => {
+        // fpnid lookup: OpenCR returns the source carrying the fpnid + its golden (via _include)
+        if (url.includes('identifier=')) {
+          return { entry: [{ resource: source }, { resource: golden }] }
+        }
+        // re-query by golden id: golden + all linked sources
+        if (url.includes('_id=golden-1')) {
+          return { entry: [{ resource: golden }, { resource: source }] }
+        }
+        return { entry: [] }
+      },
+    }))
+
+    const res = await request(app).get('/Patient/fpnid/HT-0001')
+
+    expect(res.status).toBe(200)
+    expect(res.body.id).toBe('ips-1')
+    // the identifier query must have used the fpnid system, not the source-key system
+    expect(mockGotGet.mock.calls.some(c => String(c[0]).includes(FPNID_SYSTEM))).toBe(true)
+    expect(generateConsolidatedIpsBundle).toHaveBeenCalled()
+  })
+
+  it('returns 404 when no golden record resolves for the fpnid', async () => {
+    mockGotGet.mockImplementation(() => ({ json: async () => ({ entry: [] }) }))
+
+    const res = await request(app).get('/Patient/fpnid/UNKNOWN')
+
+    expect(res.status).toBe(404)
+    expect(generateConsolidatedIpsBundle).not.toHaveBeenCalled()
   })
 })

--- a/src/routes/ips.ts
+++ b/src/routes/ips.ts
@@ -16,6 +16,7 @@ import { getMetadata } from '../lib/helpers'
 export const router = express.Router()
 
 const system = config.get('app:mpiSystem')
+const fpnidSystem = config.get('app:fpnidSystem')
 
 // Server-to-server search against the MPI (OpenCR via OpenHIM). Uses the client-registry
 // credentials — the same ones the FHIR write path uses — rather than the (empty) fhirServer creds
@@ -30,6 +31,28 @@ async function mpiSearch(query: string): Promise<R4.IPatient[]> {
   return (bundle.entry || [])
     .map(e => e.resource as R4.IPatient)
     .filter(r => r && r.resourceType === 'Patient')
+}
+
+// Resolve any site-held identifier (source key, fpnid, ...) to the golden record and every
+// linked source. OpenCR is asked for the identifier; whichever record carries it is followed to
+// its golden (per the spec: CRUID -> else source key -> plus fpnid, all resolve to the golden).
+// Returns the golden + all sources, or null when no golden is found for the identifier.
+async function resolveGoldenAndSources(
+  identifierSystem: string,
+  value: string,
+): Promise<R4.IPatient[] | null> {
+  const hits = await mpiSearch(
+    `Patient?identifier=${identifierSystem}|${value}&_include=Patient:link`,
+  )
+  const goldenRecord = hits.find(
+    x => x.meta && x.meta.tag && x.meta.tag.some(t => t.code === GOLDEN_RECORD_TAG),
+  )
+  if (!goldenRecord) {
+    return null
+  }
+  // Re-query by golden id so we get the golden + every source linked to it (not just the
+  // source that happened to carry the queried identifier).
+  return mpiSearch(`Patient?_id=${goldenRecord.id}&_include=Patient:link`)
 }
 
 router.get('/', (req: Request, res: Response) => {
@@ -52,24 +75,34 @@ router.get('/Patient/cruid/:id', async (req: Request, res: Response) => {
   res.status(200).json(ipsBundle)
 })
 
-// Consolidated IPS by a site identifier (system = app:mpiSystem). Resolves the identifier to its
-// golden record, then to all linked sources, then assembles the same consolidated IPS.
+// Consolidated IPS by biometric national FP ID (fpnid, system = app:fpnidSystem). Resolves the
+// fpnid to its golden record, then to all linked sources, then assembles the consolidated IPS.
+router.get('/Patient/fpnid/:id', async (req: Request, res: Response) => {
+  const fpnid = req.params.id
+  logger.info(sprintf('Received a request for a consolidated IPS for fpnid: %s', fpnid))
+
+  if (!fpnidSystem) {
+    logger.error('app:fpnidSystem is not configured; cannot resolve fpnid retrieval')
+    return res.sendStatus(501)
+  }
+
+  const mpiPatients = await resolveGoldenAndSources(fpnidSystem, fpnid)
+  if (mpiPatients) {
+    res.status(200).json(await generateConsolidatedIpsBundle(mpiPatients))
+  } else {
+    res.sendStatus(404)
+  }
+})
+
+// Consolidated IPS by a site identifier (system = app:mpiSystem, i.e. the source key). Resolves
+// the identifier to its golden record, then to all linked sources, then assembles the IPS.
 router.get('/Patient/:id', async (req: Request, res: Response) => {
   const patientId = req.params.id
   logger.info(sprintf('Received a request for a consolidated IPS for patient id: %s', patientId))
 
-  // Resolve the identifier to its golden record, then enumerate all linked sources by cruid.
-  const goldenRecordRes = await mpiSearch(
-    `Patient?identifier=${system}|${patientId}&_include=Patient:link`,
-  )
-  const goldenRecord = goldenRecordRes.find(
-    x => x.meta && x.meta.tag && x.meta.tag.some(t => t.code === GOLDEN_RECORD_TAG),
-  )
-
-  if (goldenRecord) {
-    const mpiPatients = await mpiSearch(`Patient?_id=${goldenRecord.id}&_include=Patient:link`)
-    const ipsBundle = await generateConsolidatedIpsBundle(mpiPatients)
-    res.status(200).send(ipsBundle)
+  const mpiPatients = await resolveGoldenAndSources(system, patientId)
+  if (mpiPatients) {
+    res.status(200).send(await generateConsolidatedIpsBundle(mpiPatients))
   } else {
     res.sendStatus(404)
   }


### PR DESCRIPTION
## What

Adds an **fpnid** (biometric national FP ID) retrieval path to the consolidated IPS mediator, completing the roaming/continuity-of-care spec's three retrieval keys:

| Retrieval key | Route |
|---|---|
| CRUID | `GET /ips/Patient/cruid/:id` (existing) |
| source key | `GET /ips/Patient/:id` (existing, `app:mpiSystem`) |
| **fpnid** | `GET /ips/Patient/fpnid/:id` (**new**, `app:fpnidSystem`) |

## How

- Extracts a shared `resolveGoldenAndSources(system, value)` helper: resolves any site-held identifier via OpenCR to the golden record, then to the golden + every linked source. Used by both the source-key and fpnid routes.
- New route `GET /Patient/fpnid/:id` resolves the biometric FP ID system (`app:fpnidSystem`, default `http://isanteplus.org/openmrs/fhir2/6-biometrics-national-reference-code`) → golden → consolidated IPS. Returns `404` when no golden resolves, `501` if `app:fpnidSystem` is unconfigured.
- Config: adds `app:fpnidSystem` default to `config_docker.json`.

## Testing

- `tsc --noEmit` clean.
- New route tests (mock MPI + IPS assembler): fpnid → golden → IPS (200), and 404 when unresolved.
- Full suite green: 7 suites, 74 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)