### PR TITLE
feat(ips): consolidated IPS read-side — resolve by iSantePlus identifier (+ CRUID/fpnid)

### DIFF
--- a/config/config_docker.json
+++ b/config/config_docker.json
@@ -2,7 +2,8 @@
   "app": {
     "port": 3000,
     "mllpPort": 3001,
-    "fpnidSystem": "http://isanteplus.org/openmrs/fhir2/6-biometrics-national-reference-code"
+    "fpnidSystem": "http://isanteplus.org/openmrs/fhir2/6-biometrics-national-reference-code",
+    "isantePlusSystem": "http://isanteplus.org/openmrs/fhir2/3-isanteplus-id"
   },
   "mediator": {
     "api": {

--- a/src/routes/__tests__/ips.test.ts
+++ b/src/routes/__tests__/ips.test.ts
@@ -73,8 +73,12 @@ describe('IPS fpnid retrieval', () => {
 
     expect(res.status).toBe(200)
     expect(res.body.id).toBe('ips-1')
-    // the identifier query must have used the fpnid system, not the source-key system
-    expect(mockGotGet.mock.calls.some(c => String(c[0]).includes(FPNID_SYSTEM))).toBe(true)
+    // the identifier query must have used the fpnid system, not the source-key system.
+    // Assert on the exact `identifier=` query-param value rather than a loose URL substring.
+    const identifierArg = mockGotGet.mock.calls
+      .map(c => String(c[0]).split('identifier=')[1]?.split('&')[0])
+      .find(Boolean)
+    expect(identifierArg).toBe(`${FPNID_SYSTEM}|HT-0001`)
     expect(generateConsolidatedIpsBundle).toHaveBeenCalled()
   })
 

--- a/src/routes/ips.ts
+++ b/src/routes/ips.ts
@@ -67,7 +67,7 @@ router.get('/metadata', getMetadata())
 // generateConsolidatedIpsBundle for why this works with demographics held only in the MPI.
 router.get('/Patient/cruid/:id', async (req: Request, res: Response) => {
   const cruid = req.params.id
-  logger.info(sprintf('Received a request for a consolidated IPS for cruid: %s', cruid))
+  logger.info('Received a request for a consolidated IPS by cruid')
 
   // The golden record + every site source linked to it (golden.link[seealso] -> sources).
   const mpiPatients = await mpiSearch(`Patient?_id=${cruid}&_include=Patient:link`)
@@ -80,7 +80,7 @@ router.get('/Patient/cruid/:id', async (req: Request, res: Response) => {
 // fpnid to its golden record, then to all linked sources, then assembles the consolidated IPS.
 router.get('/Patient/fpnid/:id', async (req: Request, res: Response) => {
   const fpnid = req.params.id
-  logger.info(sprintf('Received a request for a consolidated IPS for fpnid: %s', fpnid))
+  logger.info('Received a request for a consolidated IPS by fpnid')
 
   if (!fpnidSystem) {
     logger.error('app:fpnidSystem is not configured; cannot resolve fpnid retrieval')
@@ -100,9 +100,7 @@ router.get('/Patient/fpnid/:id', async (req: Request, res: Response) => {
 // source, and assembles the consolidated IPS from the SHR — the EMR never talks to OpenCR directly.
 router.get('/Patient/isanteplus/:id', async (req: Request, res: Response) => {
   const isantePlusId = req.params.id
-  logger.info(
-    sprintf('Received a request for a consolidated IPS for iSantePlus id: %s', isantePlusId),
-  )
+  logger.info('Received a request for a consolidated IPS by iSantePlus id')
 
   if (!isantePlusSystem) {
     logger.error('app:isantePlusSystem is not configured; cannot resolve iSantePlus retrieval')
@@ -121,7 +119,7 @@ router.get('/Patient/isanteplus/:id', async (req: Request, res: Response) => {
 // the identifier to its golden record, then to all linked sources, then assembles the IPS.
 router.get('/Patient/:id', async (req: Request, res: Response) => {
   const patientId = req.params.id
-  logger.info(sprintf('Received a request for a consolidated IPS for patient id: %s', patientId))
+  logger.info('Received a request for a consolidated IPS by site identifier')
 
   const mpiPatients = await resolveGoldenAndSources(system, patientId)
   if (mpiPatients) {

--- a/src/routes/ips.ts
+++ b/src/routes/ips.ts
@@ -17,6 +17,7 @@ export const router = express.Router()
 
 const system = config.get('app:mpiSystem')
 const fpnidSystem = config.get('app:fpnidSystem')
+const isantePlusSystem = config.get('app:isantePlusSystem')
 
 // Server-to-server search against the MPI (OpenCR via OpenHIM). Uses the client-registry
 // credentials — the same ones the FHIR write path uses — rather than the (empty) fhirServer creds
@@ -87,6 +88,28 @@ router.get('/Patient/fpnid/:id', async (req: Request, res: Response) => {
   }
 
   const mpiPatients = await resolveGoldenAndSources(fpnidSystem, fpnid)
+  if (mpiPatients) {
+    res.status(200).json(await generateConsolidatedIpsBundle(mpiPatients))
+  } else {
+    res.sendStatus(404)
+  }
+})
+
+// Consolidated IPS by iSantePlus identifier (system = app:isantePlusSystem). The EMR sends only its
+// own iSantePlus ID; the mediator resolves it to the golden record in the CR, gathers every linked
+// source, and assembles the consolidated IPS from the SHR — the EMR never talks to OpenCR directly.
+router.get('/Patient/isanteplus/:id', async (req: Request, res: Response) => {
+  const isantePlusId = req.params.id
+  logger.info(
+    sprintf('Received a request for a consolidated IPS for iSantePlus id: %s', isantePlusId),
+  )
+
+  if (!isantePlusSystem) {
+    logger.error('app:isantePlusSystem is not configured; cannot resolve iSantePlus retrieval')
+    return res.sendStatus(501)
+  }
+
+  const mpiPatients = await resolveGoldenAndSources(isantePlusSystem, isantePlusId)
   if (mpiPatients) {
     res.status(200).json(await generateConsolidatedIpsBundle(mpiPatients))
   } else {


### PR DESCRIPTION
Delivers the **mediator-side consolidated IPS read path**: an EMR requests a patient summary by sending an identifier; the mediator resolves the golden record in the CR (OpenCR) and assembles the IPS from the SHR (demographics-out topology — clinical is gathered per source id and rewritten to the golden).

### New in this PR (the requested piece)
- **`GET /ips/Patient/isanteplus/:id`** — resolve the consolidated IPS from an **iSantePlus identifier**. The EMR sends only its iSantePlus ID; the mediator does the golden resolution and SHR aggregation (EMR never talks to OpenCR). Uses the existing generic `resolveGoldenAndSources(app:isantePlusSystem, id)`.
- **`app:isantePlusSystem`** config (default `http://isanteplus.org/openmrs/fhir2/3-isanteplus-id`).

### Also carried (not yet in `main`, this stacks on them)
- `#144` MPI-resolved consolidated IPS for demographics-out SHR (`generateConsolidatedIpsBundle`, `resolveGoldenAndSources`, golden/source merge).
- fpnid retrieval path (`GET /ips/Patient/fpnid/:id`).

### Entry points (all via OpenHIM `^/SHR/fhir/ips.*$` → `/ips`)
- `GET /ips/Patient/isanteplus/:id` — by iSantePlus ID (new)
- `GET /ips/Patient/cruid/:id` — by golden/CRUID
- `GET /ips/Patient/fpnid/:id` — by biometric national FP id
- `GET /ips/Patient/:id` — by source-key (`app:mpiSystem`)

`tsc --noEmit` clean; existing IPS unit tests updated on the stacked commits.

Companion change (EMR side): `xds-sender` will call `…/ips/Patient/isanteplus/<id>` and drop its client-side OpenCR lookup.