### PR TITLE
ips: add explicit /Patient/source-key/:id route for source-key IPS lookup

### DIFF
--- a/config/config_docker.json
+++ b/config/config_docker.json
@@ -3,7 +3,8 @@
     "port": 3000,
     "mllpPort": 3001,
     "fpnidSystem": "http://isanteplus.org/openmrs/fhir2/6-biometrics-national-reference-code",
-    "isantePlusSystem": "http://isanteplus.org/openmrs/fhir2/3-isanteplus-id"
+    "isantePlusSystem": "http://isanteplus.org/openmrs/fhir2/3-isanteplus-id",
+    "mpiSystem": "http://sedish-haiti.org/fhir/source-key"
   },
   "mediator": {
     "api": {

--- a/src/routes/__tests__/ips.test.ts
+++ b/src/routes/__tests__/ips.test.ts
@@ -1,5 +1,6 @@
 const GOLDEN_TAG = '5c827da5-4858-4f3d-a50c-62ece001efea'
 const FPNID_SYSTEM = 'http://isanteplus.org/openmrs/fhir2/6-biometrics-national-reference-code'
+const SOURCE_KEY_SYSTEM = 'http://sedish-haiti.org/fhir/source-key'
 
 const golden = {
   resourceType: 'Patient',
@@ -86,6 +87,55 @@ describe('IPS fpnid retrieval', () => {
     mockGotGet.mockImplementation(() => ({ json: async () => ({ entry: [] }) }))
 
     const res = await request(app).get('/Patient/fpnid/UNKNOWN')
+
+    expect(res.status).toBe(404)
+    expect(generateConsolidatedIpsBundle).not.toHaveBeenCalled()
+  })
+})
+
+describe('IPS source-key retrieval', () => {
+  const skSource = {
+    resourceType: 'Patient',
+    id: 'src-2',
+    identifier: [{ system: SOURCE_KEY_SYSTEM, value: '73106-3' }],
+  }
+
+  beforeEach(() => {
+    mockGotGet.mockReset()
+    ;(generateConsolidatedIpsBundle as jest.Mock).mockClear()
+  })
+
+  it('resolves a source-key to the golden record and returns a consolidated IPS (200)', async () => {
+    mockGotGet.mockImplementation((url: string) => ({
+      json: async () => {
+        // source-key lookup: OpenCR returns the source carrying the key + its golden (via _include)
+        if (url.includes('identifier=')) {
+          return { entry: [{ resource: skSource }, { resource: golden }] }
+        }
+        // re-query by golden id: golden + all linked sources
+        if (url.includes('_id=golden-1')) {
+          return { entry: [{ resource: golden }, { resource: skSource }] }
+        }
+        return { entry: [] }
+      },
+    }))
+
+    const res = await request(app).get('/Patient/source-key/73106-3')
+
+    expect(res.status).toBe(200)
+    expect(res.body.id).toBe('ips-1')
+    // the identifier query must have used the source-key system, keyed on the nationally-unique key
+    const identifierArg = mockGotGet.mock.calls
+      .map(c => String(c[0]).split('identifier=')[1]?.split('&')[0])
+      .find(Boolean)
+    expect(identifierArg).toBe(`${SOURCE_KEY_SYSTEM}|73106-3`)
+    expect(generateConsolidatedIpsBundle).toHaveBeenCalled()
+  })
+
+  it('returns 404 when no golden record resolves for the source-key', async () => {
+    mockGotGet.mockImplementation(() => ({ json: async () => ({ entry: [] }) }))
+
+    const res = await request(app).get('/Patient/source-key/99999-1')
 
     expect(res.status).toBe(404)
     expect(generateConsolidatedIpsBundle).not.toHaveBeenCalled()

--- a/src/routes/ips.ts
+++ b/src/routes/ips.ts
@@ -115,6 +115,22 @@ router.get('/Patient/isanteplus/:id', async (req: Request, res: Response) => {
   }
 })
 
+// Consolidated IPS by SEDISH source-key (<mspp_code>-<patient_id>, system = app:mpiSystem). Explicit
+// route for the EMR ips module, which fetches /Patient/source-key/<key>. The source key is nationally
+// unique (unlike the per-facility iSantePlus id), so it resolves to exactly one patient. Registered
+// before /Patient/:id so the two-segment path is not swallowed by the single-segment catch-all.
+router.get('/Patient/source-key/:id', async (req: Request, res: Response) => {
+  const sourceKey = req.params.id
+  logger.info('Received a request for a consolidated IPS by source-key')
+
+  const mpiPatients = await resolveGoldenAndSources(system, sourceKey)
+  if (mpiPatients) {
+    res.status(200).json(await generateConsolidatedIpsBundle(mpiPatients))
+  } else {
+    res.sendStatus(404)
+  }
+})
+
 // Consolidated IPS by a site identifier (system = app:mpiSystem, i.e. the source key). Resolves
 // the identifier to its golden record, then to all linked sources, then assembles the IPS.
 router.get('/Patient/:id', async (req: Request, res: Response) => {


### PR DESCRIPTION
### Why
iSantePlus IDs are issued per facility and are **not** nationally unique — the same value can belong to different people at different sites, so fetching the IPS by iSantePlus ID can return another patient's summary (reproduced on sedishtest: `10010W` belongs to two people at sites 54111 and 73106).

The EMR `ips` module now fetches by the nationally-unique **SEDISH source key** (`<mspp_code>-<patient_id>`, system `http://sedish-haiti.org/fhir/source-key`) at `GET /SHR/ips/Patient/source-key/<key>` — a path that currently 404s on the mediator.

### What
- New route **`GET /Patient/source-key/:id`** (system = `app:mpiSystem`), registered before the `/Patient/:id` catch-all so the two-segment path isn't swallowed. It resolves the key to the golden record and assembles the same **consolidated** IPS the cruid/fpnid/isanteplus routes produce (`resolveGoldenAndSources` → `generateConsolidatedIpsBundle`).
- Added `app:mpiSystem` default (`…/fhir/source-key`) to `config_docker.json` so the route is self-consistent in CI/standalone (the sedish deployment already injects it at runtime).
- Two route tests (200 resolve + 404 unknown). Full suite: 77 passed / 3 pre-existing skips; `tsc --noEmit --skipLibCheck` clean.