### PR TITLE
IPS: keep every site's source key on the merged subject

### DIFF
--- a/src/workflows/__tests__/ipsWorkflows.test.ts
+++ b/src/workflows/__tests__/ipsWorkflows.test.ts
@@ -496,6 +496,56 @@ describe('generateConsolidatedIpsBundle', () => {
     expect(subjectEntry.identifier[0].value).toBe('21100-1046')
   })
 
+  it('keeps every site source key on the subject, but one identifier per other system', async () => {
+    // The requesting EMR checks the subject for ITS OWN source key before displaying the summary. Keeping
+    // only one meant the golden carried whichever site wrote last, and every other site refused to display
+    // a summary that is legitimately theirs.
+    const golden: R4.IPatient = {
+      resourceType: 'Patient',
+      id: 'gold-3',
+      meta: { tag: [{ code: GOLDEN_RECORD_TAG }] },
+    }
+    const site44: R4.IPatient = {
+      resourceType: 'Patient',
+      id: 'src-44',
+      name: [{ family: 'Turner', given: ['Bob'] }],
+      birthDate: '1996-06-20',
+      identifier: [
+        { system: 'http://sedish-haiti.org/fhir/source-key', value: '73106-96' },
+        { system: 'http://isanteplus.org/openmrs/fhir2/3-isanteplus-id', value: '10030U' },
+      ],
+    }
+    const site18: R4.IPatient = {
+      resourceType: 'Patient',
+      id: 'src-18',
+      identifier: [
+        { system: 'http://sedish-haiti.org/fhir/source-key', value: '54111-62' },
+        { system: 'http://isanteplus.org/openmrs/fhir2/3-isanteplus-id', value: '10020V' },
+      ],
+    }
+    const site54: R4.IPatient = {
+      resourceType: 'Patient',
+      id: 'src-54',
+      identifier: [{ system: 'http://sedish-haiti.org/fhir/source-key', value: '75101-73' }],
+    }
+    mockGotGet.mockImplementation(() => respond([]))
+
+    const result = await generateConsolidatedIpsBundle([golden, site44, site18, site54])
+    const subject = result.entry!.find(
+      e => (e as any).resourceType === 'Patient' && (e as any).id === 'gold-3',
+    ) as any
+    const sourceKeys = subject.identifier
+      .filter((i: any) => i.system === 'http://sedish-haiti.org/fhir/source-key')
+      .map((i: any) => i.value)
+    expect(sourceKeys.sort()).toEqual(['54111-62', '73106-96', '75101-73'])
+
+    // every other system still collapses to a single value
+    const isanteIds = subject.identifier.filter(
+      (i: any) => i.system === 'http://isanteplus.org/openmrs/fhir2/3-isanteplus-id',
+    )
+    expect(isanteIds).toHaveLength(1)
+  })
+
   it('falls back to the record itself when there is no golden tag (singleton)', async () => {
     mockGotGet.mockImplementation((url: string) => {
       if (url.includes('Observation?patient=Patient/lone-1')) return respond([obsFor('obs-9', 'lone-1')])

--- a/src/workflows/ipsWorkflows.ts
+++ b/src/workflows/ipsWorkflows.ts
@@ -377,6 +377,11 @@ export async function generateCrossFacilityIpsBundle(
 // OpenCR tags golden (master) records with this code on Patient.meta.tag.
 export const GOLDEN_RECORD_TAG = '5c827da5-4858-4f3d-a50c-62ece001efea'
 
+// The site-scoped record key (<mspp code>-<patient id>) each EMR identifies its own patient by. Same
+// setting the IPS routes resolve incoming lookups against.
+const SOURCE_KEY_SYSTEM: string =
+  config.get('app:mpiSystem') || 'http://sedish-haiti.org/fhir/source-key'
+
 // Clinical resource types gathered for a consolidated IPS, queried by the `patient` compartment
 // search param. This works even though Patient resources do NOT live in the SHR (demographics are
 // held only in the MPI/OpenCR per the SEDISH architecture), because clinical resources keep their
@@ -417,19 +422,27 @@ function mergeDemographics(golden: R4.IPatient, sources: R4.IPatient[]): R4.IPat
   const genderSrc = pick(p => !!p.gender)
   const birthSrc = pick(p => !!p.birthDate)
 
-  // The IPS subject is a single person, so show ONE identifier per system. A cross-facility golden
-  // aggregates several sources, each with its own facility-scoped source-key / iSantePlus ID; unioning
-  // them all makes the header list many source-keys and iSantePlus IDs. Keep the first value per system
-  // (golden first, then sources) and drop identifiers with no system (corruption).
+  // The IPS subject is a single person, so most systems show ONE identifier: a cross-facility golden
+  // aggregates several sources, and listing every site's iSantePlus ID would make the header unreadable.
+  //
+  // The source key is the exception and must be unioned. It is how a site recognises its own patient in
+  // a bundle: the requesting EMR checks the subject for ITS key before displaying anything. Keeping one
+  // meant the golden carried whichever site wrote last, so every other site saw a summary it could not
+  // identify and refused to display it — and the refusal moved from site to site with each sync.
+  // Identifiers with no system are corruption and are dropped either way.
   const seen = new Set<string>()
   const identifier: R4.IIdentifier[] = []
   for (const p of [golden, ...sources]) {
     for (const id of p.identifier || []) {
       const sys = id.system || ''
-      if (!sys || seen.has(sys)) {
+      if (!sys) {
         continue
       }
-      seen.add(sys)
+      const key = sys === SOURCE_KEY_SYSTEM ? `${sys}|${id.value || ''}` : sys
+      if (seen.has(key)) {
+        continue
+      }
+      seen.add(key)
       identifier.push(id)
     }
   }


### PR DESCRIPTION
## The defect

The consolidated bundle contains a single Patient — the golden record — and #149 reduced its identifiers to one per system, so a cross-facility golden would not list one iSantePlus ID per site. Correct for display identifiers, wrong for the source key.

The source key is how a site recognises its own patient in a returned bundle. The requesting EMR checks the subject for **its own** key before displaying anything, because a summary fetched by a facility-scoped identifier could belong to a different person. Keeping one key meant the golden carried whichever site wrote last, so every other site received a summary that is legitimately theirs and refused to display it — and which site got refused moved around with each sync.

Observed on golden `62f87203` (three linked site records):

```
fetch source-key 54111-62  ->  subject identifiers:  source-key = 75101-73
                                                     3-isanteplus-id = 10026F
```

The demographic fallback did not save it either: that patient's given and family names are transposed at one of the three sites, so the subject's family name did not match the requesting site's local record.

## The fix

Key the source key on `system|value` and leave every other system collapsing to its first value. The linked records are already resolved by the caller and each carries its own key, so this unions what the bundle already holds — no extra lookups, no change to how demographics are merged.

```
source-key      54111-62, 73106-96, 75101-73     (all sites)
3-isanteplus-id 10030U                            (still one)
```

## Tests

One test asserting all three site keys survive on the subject while the iSantePlus ID stays single. Verified it has teeth by running it against the previous behaviour:

```
✕ keeps every site source key on the subject, but one identifier per other system
  Expected - 2   Received + 0
```

Suite: 78 passing, 3 skipped. `tsc --noEmit` clean.

## Note

The EMR-side guard has separately been hardened to tolerate the name inversion and accept a Code National match. That is a sensible defence in depth, but this is the deterministic fix: with the union present, the check passes on the source key at every legitimate site and never reaches the demographic fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)